### PR TITLE
Fix missing Autorização Compra routes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,8 @@ import ComissaoFaixas from "./pages/ComissaoFaixas"
 import ComissaoFormulario from "./pages/ComissaoFormulario"
 import VendedorMetas from "./pages/VendedorMetas"
 import VendedorMetaFormulario from "./pages/VendedorMetaFormulario"
+import AutorizacaoCompraPage from "./pages/AutorizacaoCompra"
+import AutorizacaoCompraFormulario from "./pages/AutorizacaoCompraFormulario"
 import { AuthProvider } from "./contexts/AuthContext"
 import { ThemeProvider } from "./contexts/ThemeContext"
 
@@ -139,6 +141,36 @@ function App() {
                 <ProtectedRoute niveisPermitidos={["00", "15", "80"]}>
                   <Layout>
                     <VendedorMetaFormulario />
+                  </Layout>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/controladoria/autorizacao-compra"
+              element={
+                <ProtectedRoute niveisPermitidos={["00", "15", "80"]}>
+                  <Layout>
+                    <AutorizacaoCompraPage />
+                  </Layout>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/controladoria/autorizacao-compra/novo"
+              element={
+                <ProtectedRoute niveisPermitidos={["00", "15", "80"]}>
+                  <Layout>
+                    <AutorizacaoCompraFormulario />
+                  </Layout>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/controladoria/autorizacao-compra/editar/:id"
+              element={
+                <ProtectedRoute niveisPermitidos={["00", "15", "80"]}>
+                  <Layout>
+                    <AutorizacaoCompraFormulario />
                   </Layout>
                 </ProtectedRoute>
               }

--- a/frontend/src/pages/AutorizacaoCompra.tsx
+++ b/frontend/src/pages/AutorizacaoCompra.tsx
@@ -70,12 +70,12 @@ const AutorizacaoCompraPage: React.FC = () => {
     }, [])
 
     const handleNovo = () => {
-        navigate("/autorizacao-compra/novo")
+        navigate("/controladoria/autorizacao-compra/novo")
     }
 
     const handleEditar = (id: number | undefined) => {
         if (id) {
-            navigate(`/autorizacao-compra/editar/${id}`)
+            navigate(`/controladoria/autorizacao-compra/editar/${id}`)
         }
     }
 

--- a/frontend/src/pages/AutorizacaoCompraFormulario.tsx
+++ b/frontend/src/pages/AutorizacaoCompraFormulario.tsx
@@ -152,7 +152,7 @@ const AutorizacaoCompraFormulario: React.FC = () => {
 
             // Redirecionar após 1 segundo
             setTimeout(() => {
-                navigate("/autorizacao-compra")
+                navigate("/controladoria/autorizacao-compra")
             }, 1000)
         } catch (error) {
             console.error("Erro ao salvar autorização:", error)
@@ -167,7 +167,7 @@ const AutorizacaoCompraFormulario: React.FC = () => {
     }
 
     const handleVoltar = () => {
-        navigate("/autorizacao-compra")
+        navigate("/controladoria/autorizacao-compra")
     }
 
     if (error) {


### PR DESCRIPTION
## Summary
- register AutorizacaoCompra pages in router
- update navigation paths for Autorização de Compra pages

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859ae56cec483248f50ee9d7ab43dce