### PR TITLE
Implement AC approval locks and revert

### DIFF
--- a/backend/src/routes/autorizacaoCompraRoutes.ts
+++ b/backend/src/routes/autorizacaoCompraRoutes.ts
@@ -15,6 +15,12 @@ router.put(
     autorizacaoCompraController.autorizarControladoria,
 )
 router.put(
+    "/:id/reverter-controladoria",
+    verificarAutenticacao,
+    verificarNivel(["06"]),
+    autorizacaoCompraController.reverterControladoria,
+)
+router.put(
     "/:id/autorizar-diretoria",
     verificarAutenticacao,
     verificarNivel(["00"]),

--- a/frontend/src/pages/AutorizacaoCompra.tsx
+++ b/frontend/src/pages/AutorizacaoCompra.tsx
@@ -151,11 +151,48 @@ const AutorizacaoCompraPage: React.FC = () => {
         }
     }
 
+    const handleReverterControladoria = async (id: number | undefined) => {
+        if (!id) return
+
+        try {
+            await autorizacaoCompraService.reverterControladoria(id)
+            setSnackbar({
+                open: true,
+                message: "Autorização revertida",
+                severity: "success",
+            })
+            carregarAutorizacoes()
+        } catch (error) {
+            console.error("Erro ao reverter autorização:", error)
+            setSnackbar({
+                open: true,
+                message: "Erro ao reverter autorização",
+                severity: "error",
+            })
+        }
+    }
+
     const getStatusChip = (autorizacao: AutorizacaoCompra) => {
         if (autorizacao.autorizado_diretoria) {
-            return <Chip label="Liberada" color="success" size="small" />
+            return (
+                <Tooltip
+                    title={`Liberado em ${formatarData(
+                        autorizacao.data_autorizacao_diretoria || "",
+                    )} por ${autorizacao.usuario_diretoria || ""}`}
+                >
+                    <Chip label="Liberado Diretoria" color="success" size="small" />
+                </Tooltip>
+            )
         } else if (autorizacao.autorizado_controladoria) {
-            return <Chip label="Aguardando Diretoria" color="primary" size="small" />
+            return (
+                <Tooltip
+                    title={`Liberado em ${formatarData(
+                        autorizacao.data_autorizacao_controladoria || "",
+                    )} por ${autorizacao.usuario_controladoria || ""}`}
+                >
+                    <Chip label="Liberado Controladoria" color="primary" size="small" />
+                </Tooltip>
+            )
         } else {
             return <Chip label="Aguardando Controladoria" color="warning" size="small" />
         }
@@ -173,14 +210,11 @@ const AutorizacaoCompraPage: React.FC = () => {
 
     // Verifica se o usuário pode excluir a autorização
     const podeExcluir = (autorizacao: AutorizacaoCompra) => {
-        // Só pode excluir se for o próprio usuário que criou e não estiver autorizada
-        // Ou se for nível 00 ou 06
+        // Apenas o usuário que criou e enquanto não houver liberação
         return (
-            (autorizacao.usuario === usuario?.usuario &&
-                !autorizacao.autorizado_controladoria &&
-                !autorizacao.autorizado_diretoria) ||
-            usuario?.nivel === "00" ||
-            usuario?.nivel === "06"
+            autorizacao.usuario === usuario?.usuario &&
+            !autorizacao.autorizado_controladoria &&
+            !autorizacao.autorizado_diretoria
         )
     }
 
@@ -273,6 +307,19 @@ const AutorizacaoCompraPage: React.FC = () => {
                                                             </IconButton>
                                                         </Tooltip>
                                                     )}
+                                                    {usuario?.nivel === "06" &&
+                                                        autorizacao.autorizado_controladoria &&
+                                                        !autorizacao.autorizado_diretoria && (
+                                                            <Tooltip title="Reverter (Controladoria)">
+                                                                <IconButton
+                                                                    size="small"
+                                                                    color="warning"
+                                                                    onClick={() => handleReverterControladoria(autorizacao.id)}
+                                                                >
+                                                                    <DeleteIcon fontSize="small" />
+                                                                </IconButton>
+                                                            </Tooltip>
+                                                        )}
                                                     {podeAutorizarDiretoria(autorizacao) && (
                                                         <Tooltip title="Autorizar (Diretoria)">
                                                             <IconButton

--- a/frontend/src/services/autorizacaoCompraService.ts
+++ b/frontend/src/services/autorizacaoCompraService.ts
@@ -47,6 +47,11 @@ export const autorizarControladoria = async (id: number): Promise<AutorizacaoCom
     return response.data
 }
 
+export const reverterControladoria = async (id: number): Promise<AutorizacaoCompra> => {
+    const response = await api.put(`/autorizacao-compra/${id}/reverter-controladoria`)
+    return response.data
+}
+
 export const autorizarDiretoria = async (id: number): Promise<AutorizacaoCompra> => {
     const response = await api.put(`/autorizacao-compra/${id}/autorizar-diretoria`)
     return response.data


### PR DESCRIPTION
## Summary
- add ability to revert Controladoria authorization
- restrict editing/deleting to record creator before any approvals
- expose revert endpoint in backend API
- show status tooltips with approver and date
- add revert action in UI

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859d599d36483248c4d5020b8927f58