### PR TITLE
Fix missing parameter when listing authorizations

### DIFF
--- a/backend/src/controllers/autorizacaoCompraController.ts
+++ b/backend/src/controllers/autorizacaoCompraController.ts
@@ -21,13 +21,17 @@ export const criarAutorizacao = async (req: Request, res: Response): Promise<voi
 export const listarAutorizacoes = async (req: Request, res: Response): Promise<void> => {
     try {
         const usuario = req.usuario?.usuario
+        const nivel = req.usuario?.nivel
 
         if (!usuario) {
             res.status(401).json({ error: "Usuário não autenticado" })
             return
         }
 
-        const autorizacoes = await autorizacaoCompraService.listarAutorizacoes(usuario, nivel)
+        const autorizacoes = await autorizacaoCompraService.listarAutorizacoes(
+            usuario,
+            nivel ?? "",
+        )
         res.json(autorizacoes)
     } catch (error) {
         console.error("Erro ao listar autorizações:", error)


### PR DESCRIPTION
## Summary
- handle user level when listing purchase approvals

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6859d73b04708324bace530a9fa426a7