### PR TITLE
Atualiza Home e tema padrão

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,7 +27,7 @@ function App() {
             <Route
               path="/"
               element={
-                <ProtectedRoute niveisPermitidos={["00", "06", "15", "80"]}>
+                <ProtectedRoute>
                   <Layout>
                     <Home />
                   </Layout>
@@ -37,7 +37,7 @@ function App() {
             <Route
               path="/home"
               element={
-                <ProtectedRoute niveisPermitidos={["00", "06", "15", "80"]}>
+                <ProtectedRoute>
                   <Layout>
                     <Home />
                   </Layout>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -29,8 +29,6 @@ import {
   Label,
   ExitToApp,
   LocalOffer,
-  Brightness4 as DarkModeIcon,
-  Brightness7 as LightModeIcon,
   AttachMoney,
   ExpandLess,
   ExpandMore,
@@ -42,7 +40,6 @@ import {
 } from "@mui/icons-material"
 import { Link, useLocation, useNavigate } from "react-router-dom"
 import { useAuth } from "../contexts/AuthContext"
-import { useThemeMode } from "../contexts/ThemeContext"
 
 interface LayoutProps {
   children: ReactNode
@@ -71,7 +68,6 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   const isMobile = useMediaQuery(theme.breakpoints.down("md"))
   const location = useLocation()
   const { logout, isAuthenticated, usuario } = useAuth()
-  const { darkMode, toggleDarkMode } = useThemeMode()
   const navigate = useNavigate()
 
   // Redirecionar para login se não estiver autenticado
@@ -366,11 +362,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
             >
               {usuario?.usuario ? usuario.usuario.charAt(0) : "U"}
             </Avatar>
-            <Tooltip title="Alternar tema" placement="right">
-              <IconButton onClick={toggleDarkMode} size="small">
-                {darkMode ? <LightModeIcon /> : <DarkModeIcon />}
-              </IconButton>
-            </Tooltip>
+            {/* Botão de alternância de tema removido */}
           </>
         ) : (
           // Layout horizontal quando o menu está expandido
@@ -395,11 +387,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
                 </Typography>
               </Box>
             </Box>
-            <Tooltip title="Alternar tema">
-              <IconButton onClick={toggleDarkMode} size="small">
-                {darkMode ? <LightModeIcon /> : <DarkModeIcon />}
-              </IconButton>
-            </Tooltip>
+            {/* Botão de alternância de tema removido */}
           </>
         )}
       </Box>
@@ -457,14 +445,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
           >
             <MenuIcon />
           </IconButton>
-          <IconButton
-            color="primary"
-            aria-label="toggle theme"
-            onClick={toggleDarkMode}
-            sx={{ position: "fixed", top: 10, right: 10, zIndex: 1300, bgcolor: "white" }}
-          >
-            {darkMode ? <LightModeIcon /> : <DarkModeIcon />}
-          </IconButton>
+          {/* Botão de alternância de tema removido */}
           <Drawer
             variant="temporary"
             open={drawerOpen}

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -6,7 +6,7 @@ import { useAuth } from "../contexts/AuthContext"
 
 interface ProtectedRouteProps {
     children: React.ReactNode
-    niveisPermitidos: string[]
+    niveisPermitidos?: string[]
 }
 
 const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children, niveisPermitidos }) => {
@@ -17,7 +17,7 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children, niveisPermiti
         loading,
         niveisPermitidos,
         usuario,
-        temPermissao: usuario ? temPermissao(niveisPermitidos) : false,
+        temPermissao: usuario && niveisPermitidos ? temPermissao(niveisPermitidos) : false,
     })
 
     if (loading) {
@@ -30,7 +30,7 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children, niveisPermiti
         return <Navigate to="/login" replace />
     }
 
-    if (!temPermissao(niveisPermitidos)) {
+    if (niveisPermitidos && niveisPermitidos.length > 0 && !temPermissao(niveisPermitidos)) {
         console.log("ProtectedRoute: Sem permissão, redirecionando para /home")
         return <Navigate to="/home" replace />
     }

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -8,23 +8,15 @@ import CssBaseline from "@mui/material/CssBaseline"
 
 type ThemeContextType = {
     darkMode: boolean
-    toggleDarkMode: () => void
 }
 
 const ThemeContext = createContext<ThemeContextType>({
     darkMode: false,
-    toggleDarkMode: () => { },
 })
 
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-    // Recuperar preferência salva ou usar preferência do sistema
+    // Usar preferência do sistema ao iniciar
     const [darkMode, setDarkMode] = useState<boolean>(() => {
-        // Verificar localStorage primeiro
-        const savedMode = localStorage.getItem("darkMode")
-        if (savedMode !== null) {
-            return savedMode === "true"
-        }
-        // Caso contrário, verificar preferência do sistema
         if (typeof window !== "undefined") {
             return window.matchMedia("(prefers-color-scheme: dark)").matches
         }
@@ -75,24 +67,11 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         )
     }, [darkMode])
 
-    // Alternar entre temas
-    const toggleDarkMode = () => {
-        setDarkMode((prevMode) => !prevMode)
-    }
-
-    // Salvar preferência quando mudar
-    useEffect(() => {
-        localStorage.setItem("darkMode", String(darkMode))
-    }, [darkMode])
-
     // Sincronizar com mudanças na preferência do sistema
     useEffect(() => {
         const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)")
         const handleChange = (e: MediaQueryListEvent) => {
-            // Só atualizar automaticamente se o usuário não tiver definido uma preferência
-            if (localStorage.getItem("darkMode") === null) {
-                setDarkMode(e.matches)
-            }
+            setDarkMode(e.matches)
         }
 
         // Adicionar listener para mudanças na preferência do sistema
@@ -107,7 +86,7 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     }, [])
 
     return (
-        <ThemeContext.Provider value={{ darkMode, toggleDarkMode }}>
+        <ThemeContext.Provider value={{ darkMode }}>
             <MuiThemeProvider theme={theme}>
                 <CssBaseline />
                 {children}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type React from "react"
-import { Box, Typography, Paper, Grid, Button } from "@mui/material"
+import { Box, Typography, Paper } from "@mui/material"
 import { useAuth } from "../contexts/AuthContext"
 
 const Home: React.FC = () => {
@@ -25,34 +25,7 @@ const Home: React.FC = () => {
                 </Typography>
             </Paper>
 
-            <Grid container spacing={3}>
-                <Grid item xs={12}>
-                    <Typography variant="h6" gutterBottom>
-                        Acesso Rápido
-                    </Typography>
-                </Grid>
-                <Grid item xs={12} sm={6} md={4}>
-                    <Button variant="contained" color="primary" fullWidth href="/produtos-fora" sx={{ p: 2, height: "100%" }}>
-                        Produtos Enco-Fora
-                    </Button>
-                </Grid>
-                <Grid item xs={12} sm={6} md={4}>
-                    <Button
-                        variant="contained"
-                        color="primary"
-                        fullWidth
-                        href="/produtos-etiquetas"
-                        sx={{ p: 2, height: "100%" }}
-                    >
-                        Produtos Etiquetas
-                    </Button>
-                </Grid>
-                <Grid item xs={12} sm={6} md={4}>
-                    <Button variant="contained" color="primary" fullWidth href="/promocao" sx={{ p: 2, height: "100%" }}>
-                        Produtos Promoção
-                    </Button>
-                </Grid>
-            </Grid>
+            {/* Seção de acesso rápido removida conforme solicitação */}
         </Box>
     )
 }


### PR DESCRIPTION
## Summary
- remove seção de acesso rápido da Home
- permite acesso à rota Home para qualquer nível
- remove botão de alternância de tema
- usa preferência do sistema para definir modo escuro/claro

## Testing
- `npm run build` *(fails: next not found)*
- `npm run build` in `frontend/` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a7960677883249b2856bda47d86ef