### PR TITLE
Implement theme toggling and remove login level restriction

### DIFF
--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -19,9 +19,9 @@ export const autenticarUsuario = async (usuario: string, senha: string): Promise
 
         // Consultar usuário na view
         const query = `
-      SELECT usuario, codusuario, nivel 
-      FROM vs_pwb_usuarios 
-      WHERE usuario = $1 AND senha = $2 AND nivel IN ('00','06','15','80')
+      SELECT usuario, codusuario, nivel
+      FROM vs_pwb_usuarios
+      WHERE usuario = $1 AND senha = $2
     `
 
         const result = await pool.query(query, [usuarioUpper, senhaMD5])

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -29,6 +29,8 @@ import {
   Label,
   ExitToApp,
   LocalOffer,
+  Brightness4 as DarkModeIcon,
+  Brightness7 as LightModeIcon,
   AttachMoney,
   ExpandLess,
   ExpandMore,
@@ -40,6 +42,7 @@ import {
 } from "@mui/icons-material"
 import { Link, useLocation, useNavigate } from "react-router-dom"
 import { useAuth } from "../contexts/AuthContext"
+import { useThemeMode } from "../contexts/ThemeContext"
 
 interface LayoutProps {
   children: ReactNode
@@ -68,6 +71,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   const isMobile = useMediaQuery(theme.breakpoints.down("md"))
   const location = useLocation()
   const { logout, isAuthenticated, usuario } = useAuth()
+  const { darkMode, toggleDarkMode } = useThemeMode()
   const navigate = useNavigate()
 
   // Redirecionar para login se não estiver autenticado
@@ -362,7 +366,11 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
             >
               {usuario?.usuario ? usuario.usuario.charAt(0) : "U"}
             </Avatar>
-            {/* Botão de alternância de tema removido */}
+            <Tooltip title="Alternar tema" placement="right">
+              <IconButton onClick={toggleDarkMode} size="small">
+                {darkMode ? <LightModeIcon /> : <DarkModeIcon />}
+              </IconButton>
+            </Tooltip>
           </>
         ) : (
           // Layout horizontal quando o menu está expandido
@@ -387,7 +395,11 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
                 </Typography>
               </Box>
             </Box>
-            {/* Botão de alternância de tema removido */}
+            <Tooltip title="Alternar tema">
+              <IconButton onClick={toggleDarkMode} size="small">
+                {darkMode ? <LightModeIcon /> : <DarkModeIcon />}
+              </IconButton>
+            </Tooltip>
           </>
         )}
       </Box>
@@ -445,7 +457,14 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
           >
             <MenuIcon />
           </IconButton>
-          {/* Botão de alternância de tema removido */}
+          <IconButton
+            color="primary"
+            aria-label="toggle theme"
+            onClick={toggleDarkMode}
+            sx={{ position: "fixed", top: 10, right: 10, zIndex: 1300, bgcolor: "white" }}
+          >
+            {darkMode ? <LightModeIcon /> : <DarkModeIcon />}
+          </IconButton>
           <Drawer
             variant="temporary"
             open={drawerOpen}

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -8,17 +8,22 @@ import CssBaseline from "@mui/material/CssBaseline"
 
 type ThemeContextType = {
     darkMode: boolean
+    toggleDarkMode: () => void
 }
 
 const ThemeContext = createContext<ThemeContextType>({
     darkMode: false,
+    toggleDarkMode: () => {}
 })
 
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-    // Usar preferência do sistema ao iniciar
+    // Usar preferência salva ou padrão claro
     const [darkMode, setDarkMode] = useState<boolean>(() => {
         if (typeof window !== "undefined") {
-            return window.matchMedia("(prefers-color-scheme: dark)").matches
+            const savedMode = localStorage.getItem("darkMode")
+            if (savedMode !== null) {
+                return savedMode === "true"
+            }
         }
         return false
     })
@@ -67,11 +72,24 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         )
     }, [darkMode])
 
+    // Alternar entre temas
+    const toggleDarkMode = () => {
+        setDarkMode((prevMode) => !prevMode)
+    }
+
+    // Salvar preferência quando mudar
+    useEffect(() => {
+        localStorage.setItem("darkMode", String(darkMode))
+    }, [darkMode])
+
     // Sincronizar com mudanças na preferência do sistema
     useEffect(() => {
         const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)")
         const handleChange = (e: MediaQueryListEvent) => {
-            setDarkMode(e.matches)
+            // Só atualizar automaticamente se o usuário não tiver definido uma preferência
+            if (localStorage.getItem("darkMode") === null) {
+                setDarkMode(e.matches)
+            }
         }
 
         // Adicionar listener para mudanças na preferência do sistema
@@ -86,7 +104,7 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     }, [])
 
     return (
-        <ThemeContext.Provider value={{ darkMode }}>
+        <ThemeContext.Provider value={{ darkMode, toggleDarkMode }}>
             <MuiThemeProvider theme={theme}>
                 <CssBaseline />
                 {children}


### PR DESCRIPTION
## Summary
- allow any user level in backend authentication
- reintroduce dark mode toggle with light default

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: missing script)*
- `npx tsc --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685a7cad8c38832490146fbe300df003