### PR TITLE
Add details view for purchase authorization

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import VendedorMetas from "./pages/VendedorMetas"
 import VendedorMetaFormulario from "./pages/VendedorMetaFormulario"
 import AutorizacaoCompraPage from "./pages/AutorizacaoCompra"
 import AutorizacaoCompraFormulario from "./pages/AutorizacaoCompraFormulario"
+import AutorizacaoCompraDetalhes from "./pages/AutorizacaoCompraDetalhes"
 import { AuthProvider } from "./contexts/AuthContext"
 import { ThemeProvider } from "./contexts/ThemeContext"
 
@@ -171,6 +172,16 @@ function App() {
                 <ProtectedRoute niveisPermitidos={["00", "06", "15", "80"]}>
                   <Layout>
                     <AutorizacaoCompraFormulario />
+                  </Layout>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/controladoria/autorizacao-compra/visualizar/:id"
+              element={
+                <ProtectedRoute niveisPermitidos={["00", "06", "15", "80"]}>
+                  <Layout>
+                    <AutorizacaoCompraDetalhes />
                   </Layout>
                 </ProtectedRoute>
               }

--- a/frontend/src/pages/AutorizacaoCompra.tsx
+++ b/frontend/src/pages/AutorizacaoCompra.tsx
@@ -29,6 +29,7 @@ import AddIcon from "@mui/icons-material/Add"
 import EditIcon from "@mui/icons-material/Edit"
 import DeleteIcon from "@mui/icons-material/Delete"
 import CheckCircleIcon from "@mui/icons-material/CheckCircle"
+import { Visibility as VisibilityIcon } from "@mui/icons-material"
 import { useAuth } from "../contexts/AuthContext"
 import * as autorizacaoCompraService from "../services/autorizacaoCompraService"
 import { formatarData, formatarMoeda } from "../utils/formatters"
@@ -76,6 +77,12 @@ const AutorizacaoCompraPage: React.FC = () => {
     const handleEditar = (id: number | undefined) => {
         if (id) {
             navigate(`/controladoria/autorizacao-compra/editar/${id}`)
+        }
+    }
+
+    const handleVisualizar = (id: number | undefined) => {
+        if (id) {
+            navigate(`/controladoria/autorizacao-compra/visualizar/${id}`)
         }
     }
 
@@ -173,29 +180,54 @@ const AutorizacaoCompraPage: React.FC = () => {
     }
 
     const getStatusChip = (autorizacao: AutorizacaoCompra) => {
-        if (autorizacao.autorizado_diretoria) {
-            return (
+        const chips: React.ReactNode[] = []
+
+        if (autorizacao.autorizado_controladoria) {
+            chips.push(
                 <Tooltip
+                    key="ctrl"
+                    title={`Liberado em ${formatarData(
+                        autorizacao.data_autorizacao_controladoria || "",
+                    )} por ${autorizacao.usuario_controladoria || ""}`}
+                >
+                    <Chip
+                        label="Liberado Controladoria"
+                        color="primary"
+                        size="small"
+                        sx={{ mr: 0.5 }}
+                    />
+                </Tooltip>,
+            )
+        } else {
+            chips.push(
+                <Chip
+                    key="aguarda"
+                    label="Aguardando Controladoria"
+                    color="warning"
+                    size="small"
+                    sx={{ mr: 0.5 }}
+                />,
+            )
+        }
+
+        if (autorizacao.autorizado_diretoria) {
+            chips.push(
+                <Tooltip
+                    key="dir"
                     title={`Liberado em ${formatarData(
                         autorizacao.data_autorizacao_diretoria || "",
                     )} por ${autorizacao.usuario_diretoria || ""}`}
                 >
                     <Chip label="Liberado Diretoria" color="success" size="small" />
-                </Tooltip>
+                </Tooltip>,
             )
-        } else if (autorizacao.autorizado_controladoria) {
-            return (
-                <Tooltip
-                    title={`Liberado em ${formatarData(
-                        autorizacao.data_autorizacao_controladoria || "",
-                    )} por ${autorizacao.usuario_controladoria || ""}`}
-                >
-                    <Chip label="Liberado Controladoria" color="primary" size="small" />
-                </Tooltip>
-            )
-        } else {
-            return <Chip label="Aguardando Controladoria" color="warning" size="small" />
         }
+
+        return (
+            <Box display="flex" flexWrap="wrap">
+                {chips}
+            </Box>
+        )
     }
 
     // Verifica se o usuário pode editar a autorização
@@ -282,6 +314,11 @@ const AutorizacaoCompraPage: React.FC = () => {
                                             <TableCell>{getStatusChip(autorizacao)}</TableCell>
                                             <TableCell>
                                                 <Box display="flex">
+                                                    <Tooltip title="Visualizar">
+                                                        <IconButton size="small" color="info" onClick={() => handleVisualizar(autorizacao.id)}>
+                                                            <VisibilityIcon fontSize="small" />
+                                                        </IconButton>
+                                                    </Tooltip>
                                                     {podeEditar(autorizacao) && (
                                                         <Tooltip title="Editar">
                                                             <IconButton size="small" onClick={() => handleEditar(autorizacao.id)}>

--- a/frontend/src/pages/AutorizacaoCompraDetalhes.tsx
+++ b/frontend/src/pages/AutorizacaoCompraDetalhes.tsx
@@ -1,0 +1,117 @@
+"use client"
+
+import React, { useEffect, useState } from "react"
+import { useNavigate, useParams } from "react-router-dom"
+import {
+    Box,
+    Paper,
+    Typography,
+    Button,
+    CircularProgress,
+} from "@mui/material"
+import ArrowBackIcon from "@mui/icons-material/ArrowBack"
+import * as autorizacaoCompraService from "../services/autorizacaoCompraService"
+import { formatarData, formatarMoeda } from "../utils/formatters"
+import type { AutorizacaoCompra } from "../types"
+
+const AutorizacaoCompraDetalhes: React.FC = () => {
+    const { id } = useParams<{ id: string }>()
+    const navigate = useNavigate()
+    const [loading, setLoading] = useState(true)
+    const [autorizacao, setAutorizacao] = useState<AutorizacaoCompra | null>(null)
+
+    useEffect(() => {
+        const carregar = async () => {
+            if (!id) return
+            try {
+                const data = await autorizacaoCompraService.obterAutorizacao(Number(id))
+                setAutorizacao(data)
+            } catch (error) {
+                console.error("Erro ao obter autorização:", error)
+            } finally {
+                setLoading(false)
+            }
+        }
+
+        carregar()
+    }, [id])
+
+    const handleVoltar = () => {
+        navigate("/controladoria/autorizacao-compra")
+    }
+
+    if (loading) {
+        return (
+            <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
+                <CircularProgress />
+            </Box>
+        )
+    }
+
+    if (!autorizacao) {
+        return (
+            <Box p={3}>
+                <Paper sx={{ p: 3 }}>
+                    <Typography color="error" gutterBottom>
+                        Autorização não encontrada
+                    </Typography>
+                    <Button startIcon={<ArrowBackIcon />} onClick={handleVoltar}>
+                        Voltar
+                    </Button>
+                </Paper>
+            </Box>
+        )
+    }
+
+    return (
+        <Box p={3}>
+            <Paper sx={{ p: 3 }}>
+                <Box display="flex" justifyContent="space-between" alignItems="center" mb={3}>
+                    <Typography variant="h5" component="h1">
+                        Detalhes da Autorização de Compra
+                    </Typography>
+                    <Button startIcon={<ArrowBackIcon />} onClick={handleVoltar}>
+                        Voltar
+                    </Button>
+                </Box>
+                <Typography gutterBottom>
+                    <strong>Usuário:</strong> {autorizacao.usuario}
+                </Typography>
+                <Typography gutterBottom>
+                    <strong>Loja:</strong> {autorizacao.loja}
+                </Typography>
+                <Typography gutterBottom>
+                    <strong>Setor:</strong> {autorizacao.setor}
+                </Typography>
+                <Typography gutterBottom>
+                    <strong>Fornecedor:</strong> {autorizacao.fornecedor}
+                </Typography>
+                <Typography gutterBottom>
+                    <strong>Valor:</strong> {formatarMoeda(autorizacao.valor)}
+                </Typography>
+                <Typography gutterBottom>
+                    <strong>Observação:</strong> {autorizacao.observacao || "-"}
+                </Typography>
+                <Typography gutterBottom>
+                    <strong>Data/Hora Criação:</strong> {formatarData(autorizacao.data_criacao || "")} {autorizacao.hora_criacao}
+                </Typography>
+                <Typography gutterBottom>
+                    <strong>Controladoria:</strong>
+                    {" "}
+                    {autorizacao.autorizado_controladoria
+                        ? `Liberado em ${formatarData(autorizacao.data_autorizacao_controladoria || "")} por ${autorizacao.usuario_controladoria}`
+                        : "Aguardando"}
+                </Typography>
+                <Typography gutterBottom>
+                    <strong>Diretoria:</strong>
+                    {" "}
+                    {autorizacao.autorizado_diretoria
+                        ? `Liberado em ${formatarData(autorizacao.data_autorizacao_diretoria || "")} por ${autorizacao.usuario_diretoria}`
+                        : "Aguardando"}
+                </Typography>
+            </Paper>
+        </Box>
+    )
+}
+
+export default AutorizacaoCompraDetalhes


### PR DESCRIPTION
## Summary
- show both "Liberado Controladoria" and "Liberado Diretoria" chips
- add a visibility action
- create page to see authorization details
- wire new page into the router

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm test` in `frontend` *(fails: `react-scripts: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685a83c46c4883249c49e29a6bc1e516