### PR TITLE
Implement access control module

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -6,6 +6,7 @@ import comissaoRoutes from "./routes/comissaoRoutes"
 import authRoutes from "./routes/authRoutes"
 import vendedorMetaRoutes from "./routes/vendedorMetaRoutes"
 import autorizacaoCompraRoutes from "./routes/autorizacaoCompraRoutes"
+import controleAcessoRoutes from "./routes/controleAcessoRoutes"
 import { corsMiddleware } from "./config/cors"
 
 // Carrega as variáveis de ambiente antes de qualquer outra operação
@@ -25,6 +26,7 @@ app.use("/api/comissoes", comissaoRoutes)
 app.use("/api/auth", authRoutes)
 app.use("/api/vendedor-metas", vendedorMetaRoutes)
 app.use("/api/autorizacao-compra", autorizacaoCompraRoutes)
+app.use("/api/controle-acesso", controleAcessoRoutes)
 
 // Rota de teste para verificar se o servidor está funcionando
 app.get("/", (req, res) => {

--- a/backend/src/controllers/controleAcessoController.ts
+++ b/backend/src/controllers/controleAcessoController.ts
@@ -1,0 +1,116 @@
+import type { Request, Response } from "express"
+import * as acessoService from "../services/controleAcessoService"
+
+export const listarModulos = async (req: Request, res: Response): Promise<void> => {
+    try {
+        const modulos = await acessoService.getModulos()
+        res.json(modulos)
+    } catch (error) {
+        console.error("Erro ao listar módulos:", error)
+        res.status(500).json({ error: "Erro ao listar módulos" })
+    }
+}
+
+export const criarModulo = async (req: Request, res: Response): Promise<void> => {
+    try {
+        const modulo = await acessoService.criarModulo(req.body)
+        res.status(201).json(modulo)
+    } catch (error) {
+        console.error("Erro ao criar módulo:", error)
+        res.status(500).json({ error: "Erro ao criar módulo" })
+    }
+}
+
+export const atualizarModulo = async (req: Request, res: Response): Promise<void> => {
+    try {
+        const id = Number.parseInt(req.params.id, 10)
+        const modulo = await acessoService.atualizarModulo(id, req.body)
+        res.json(modulo)
+    } catch (error) {
+        console.error("Erro ao atualizar módulo:", error)
+        res.status(500).json({ error: "Erro ao atualizar módulo" })
+    }
+}
+
+export const excluirModulo = async (req: Request, res: Response): Promise<void> => {
+    try {
+        const id = Number.parseInt(req.params.id, 10)
+        const sucesso = await acessoService.excluirModulo(id)
+        if (sucesso) {
+            res.json({ message: "Módulo excluído" })
+        } else {
+            res.status(404).json({ error: "Módulo não encontrado" })
+        }
+    } catch (error) {
+        console.error("Erro ao excluir módulo:", error)
+        res.status(500).json({ error: "Erro ao excluir módulo" })
+    }
+}
+
+export const listarNiveis = async (req: Request, res: Response): Promise<void> => {
+    try {
+        const niveis = await acessoService.getNiveisAcesso()
+        res.json(niveis)
+    } catch (error) {
+        console.error("Erro ao listar níveis:", error)
+        res.status(500).json({ error: "Erro ao listar níveis" })
+    }
+}
+
+export const criarNivel = async (req: Request, res: Response): Promise<void> => {
+    try {
+        const nivel = await acessoService.criarNivelAcesso(req.body)
+        res.status(201).json(nivel)
+    } catch (error) {
+        console.error("Erro ao criar nível:", error)
+        res.status(500).json({ error: "Erro ao criar nível" })
+    }
+}
+
+export const atualizarNivel = async (req: Request, res: Response): Promise<void> => {
+    try {
+        const codigo = req.params.codigo
+        const nivel = await acessoService.atualizarNivelAcesso(codigo, req.body)
+        res.json(nivel)
+    } catch (error) {
+        console.error("Erro ao atualizar nível:", error)
+        res.status(500).json({ error: "Erro ao atualizar nível" })
+    }
+}
+
+export const excluirNivel = async (req: Request, res: Response): Promise<void> => {
+    try {
+        const codigo = req.params.codigo
+        const sucesso = await acessoService.excluirNivelAcesso(codigo)
+        if (sucesso) {
+            res.json({ message: "Nível excluído" })
+        } else {
+            res.status(404).json({ error: "Nível não encontrado" })
+        }
+    } catch (error) {
+        console.error("Erro ao excluir nível:", error)
+        res.status(500).json({ error: "Erro ao excluir nível" })
+    }
+}
+
+export const listarPermissoes = async (req: Request, res: Response): Promise<void> => {
+    try {
+        const codigo = req.params.codigo
+        const permissoes = await acessoService.getPermissoesNivel(codigo)
+        res.json(permissoes)
+    } catch (error) {
+        console.error("Erro ao listar permissões:", error)
+        res.status(500).json({ error: "Erro ao listar permissões" })
+    }
+}
+
+export const salvarPermissoes = async (req: Request, res: Response): Promise<void> => {
+    try {
+        const codigo = req.params.codigo
+        await acessoService.salvarPermissoesNivel(codigo, req.body)
+        res.json({ message: "Permissões salvas" })
+    } catch (error) {
+        console.error("Erro ao salvar permissões:", error)
+        res.status(500).json({ error: "Erro ao salvar permissões" })
+    }
+}

--- a/backend/src/models/Modulo.ts
+++ b/backend/src/models/Modulo.ts
@@ -1,0 +1,8 @@
+export interface Modulo {
+    id: number
+    nome: string
+    rota: string
+    icone?: string
+    ordem?: number
+    ativo: boolean
+}

--- a/backend/src/models/NivelAcesso.ts
+++ b/backend/src/models/NivelAcesso.ts
@@ -1,0 +1,5 @@
+export interface NivelAcesso {
+    codigo: string
+    descricao: string
+    ativo: boolean
+}

--- a/backend/src/models/PermissaoNivel.ts
+++ b/backend/src/models/PermissaoNivel.ts
@@ -1,0 +1,8 @@
+export interface PermissaoNivel {
+    codigo_nivel: string
+    id_modulo: number
+    visualizar: boolean
+    incluir: boolean
+    editar: boolean
+    excluir: boolean
+}

--- a/backend/src/routes/controleAcessoRoutes.ts
+++ b/backend/src/routes/controleAcessoRoutes.ts
@@ -1,0 +1,22 @@
+import { Router } from "express"
+import { verificarAutenticacao, verificarNivel } from "../middlewares/authMiddleware"
+import * as controleAcessoController from "../controllers/controleAcessoController"
+
+const router = Router()
+
+router.use(verificarAutenticacao)
+
+router.get("/modulos", controleAcessoController.listarModulos)
+router.post("/modulos", verificarNivel(["00"]), controleAcessoController.criarModulo)
+router.put("/modulos/:id", verificarNivel(["00"]), controleAcessoController.atualizarModulo)
+router.delete("/modulos/:id", verificarNivel(["00"]), controleAcessoController.excluirModulo)
+
+router.get("/niveis", controleAcessoController.listarNiveis)
+router.post("/niveis", verificarNivel(["00"]), controleAcessoController.criarNivel)
+router.put("/niveis/:codigo", verificarNivel(["00"]), controleAcessoController.atualizarNivel)
+router.delete("/niveis/:codigo", verificarNivel(["00"]), controleAcessoController.excluirNivel)
+
+router.get("/permissoes/:codigo", controleAcessoController.listarPermissoes)
+router.put("/permissoes/:codigo", verificarNivel(["00"]), controleAcessoController.salvarPermissoes)
+
+export default router

--- a/backend/src/services/controleAcessoService.ts
+++ b/backend/src/services/controleAcessoService.ts
@@ -1,0 +1,159 @@
+import pool from "../config/database"
+import type { Modulo } from "../models/Modulo"
+import type { NivelAcesso } from "../models/NivelAcesso"
+import type { PermissaoNivel } from "../models/PermissaoNivel"
+
+export const getModulos = async (): Promise<Modulo[]> => {
+    const query = `SELECT id, nome, rota, icone, ordem, ativo FROM scc_modulos ORDER BY ordem, nome`
+    const result = await pool.query(query)
+    return result.rows
+}
+
+export const criarModulo = async (modulo: Omit<Modulo, "id">): Promise<Modulo> => {
+    const query = `
+        INSERT INTO scc_modulos (nome, rota, icone, ordem, ativo)
+        VALUES ($1, $2, $3, $4, $5)
+        RETURNING id, nome, rota, icone, ordem, ativo
+    `
+    const values = [modulo.nome, modulo.rota, modulo.icone, modulo.ordem, modulo.ativo ?? true]
+    const result = await pool.query(query, values)
+    return result.rows[0]
+}
+
+export const atualizarModulo = async (id: number, modulo: Partial<Modulo>): Promise<Modulo> => {
+    const campos = []
+    const valores: any[] = []
+    let contador = 1
+
+    if (modulo.nome !== undefined) {
+        campos.push(`nome = $${contador}`)
+        valores.push(modulo.nome)
+        contador++
+    }
+    if (modulo.rota !== undefined) {
+        campos.push(`rota = $${contador}`)
+        valores.push(modulo.rota)
+        contador++
+    }
+    if (modulo.icone !== undefined) {
+        campos.push(`icone = $${contador}`)
+        valores.push(modulo.icone)
+        contador++
+    }
+    if (modulo.ordem !== undefined) {
+        campos.push(`ordem = $${contador}`)
+        valores.push(modulo.ordem)
+        contador++
+    }
+    if (modulo.ativo !== undefined) {
+        campos.push(`ativo = $${contador}`)
+        valores.push(modulo.ativo)
+        contador++
+    }
+
+    if (campos.length === 0) {
+        throw new Error("Nenhum campo para atualizar")
+    }
+
+    const query = `UPDATE scc_modulos SET ${campos.join(", ")} WHERE id = $${contador} RETURNING id, nome, rota, icone, ordem, ativo`
+    valores.push(id)
+    const result = await pool.query(query, valores)
+    return result.rows[0]
+}
+
+export const excluirModulo = async (id: number): Promise<boolean> => {
+    const query = `DELETE FROM scc_modulos WHERE id = $1`
+    const result = await pool.query(query, [id])
+    return (result.rowCount ?? 0) > 0
+}
+
+export const getNiveisAcesso = async (): Promise<NivelAcesso[]> => {
+    const query = `SELECT codigo, descricao, ativo FROM scc_niveis_acesso ORDER BY codigo`
+    const result = await pool.query(query)
+    return result.rows
+}
+
+export const criarNivelAcesso = async (nivel: NivelAcesso): Promise<NivelAcesso> => {
+    const query = `
+        INSERT INTO scc_niveis_acesso (codigo, descricao, ativo)
+        VALUES ($1, $2, $3)
+        RETURNING codigo, descricao, ativo
+    `
+    const values = [nivel.codigo, nivel.descricao, nivel.ativo ?? true]
+    const result = await pool.query(query, values)
+    return result.rows[0]
+}
+
+export const atualizarNivelAcesso = async (codigo: string, nivel: Partial<NivelAcesso>): Promise<NivelAcesso> => {
+    const campos = []
+    const valores: any[] = []
+    let contador = 1
+
+    if (nivel.descricao !== undefined) {
+        campos.push(`descricao = $${contador}`)
+        valores.push(nivel.descricao)
+        contador++
+    }
+    if (nivel.ativo !== undefined) {
+        campos.push(`ativo = $${contador}`)
+        valores.push(nivel.ativo)
+        contador++
+    }
+
+    if (campos.length === 0) {
+        throw new Error("Nenhum campo para atualizar")
+    }
+
+    const query = `UPDATE scc_niveis_acesso SET ${campos.join(", ")} WHERE codigo = $${contador} RETURNING codigo, descricao, ativo`
+    valores.push(codigo)
+    const result = await pool.query(query, valores)
+    return result.rows[0]
+}
+
+export const excluirNivelAcesso = async (codigo: string): Promise<boolean> => {
+    const query = `DELETE FROM scc_niveis_acesso WHERE codigo = $1`
+    const result = await pool.query(query, [codigo])
+    return (result.rowCount ?? 0) > 0
+}
+
+export const getPermissoesNivel = async (codigo: string): Promise<PermissaoNivel[]> => {
+    const query = `
+        SELECT codigo_nivel, id_modulo, visualizar, incluir, editar, excluir
+        FROM scc_permissoes_nivel
+        WHERE codigo_nivel = $1
+        ORDER BY id_modulo
+    `
+    const result = await pool.query(query, [codigo])
+    return result.rows
+}
+
+export const salvarPermissoesNivel = async (codigo: string, permissoes: PermissaoNivel[]): Promise<void> => {
+    const client = await pool.connect()
+    try {
+        await client.query("BEGIN")
+
+        for (const perm of permissoes) {
+            const query = `
+                INSERT INTO scc_permissoes_nivel (codigo_nivel, id_modulo, visualizar, incluir, editar, excluir)
+                VALUES ($1, $2, $3, $4, $5, $6)
+                ON CONFLICT (codigo_nivel, id_modulo)
+                DO UPDATE SET visualizar = EXCLUDED.visualizar, incluir = EXCLUDED.incluir, editar = EXCLUDED.editar, excluir = EXCLUDED.excluir
+            `
+            await client.query(query, [
+                codigo,
+                perm.id_modulo,
+                perm.visualizar,
+                perm.incluir,
+                perm.editar,
+                perm.excluir,
+            ])
+        }
+
+        await client.query("COMMIT")
+    } catch (error) {
+        await client.query("ROLLBACK")
+        throw error
+    } finally {
+        client.release()
+    }
+}


### PR DESCRIPTION
## Summary
- add models for Modulo, NivelAcesso and PermissaoNivel
- add service `controleAcessoService` with CRUD logic
- add controller and routes for access control configuration
- hook new routes into the backend app

## Testing
- `npm run --prefix backend build` *(fails: cannot find module 'express' or other type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_685a8766b0388324b168a78e41c66a0c