### PR TITLE
Add Controle de Acesso module

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,9 @@ import VendedorMetaFormulario from "./pages/VendedorMetaFormulario"
 import AutorizacaoCompraPage from "./pages/AutorizacaoCompra"
 import AutorizacaoCompraFormulario from "./pages/AutorizacaoCompraFormulario"
 import AutorizacaoCompraDetalhes from "./pages/AutorizacaoCompraDetalhes"
+import ControleAcessoModulos from "./pages/ControleAcessoModulos"
+import ControleAcessoNiveis from "./pages/ControleAcessoNiveis"
+import ControleAcessoPermissoes from "./pages/ControleAcessoPermissoes"
 import { AuthProvider } from "./contexts/AuthContext"
 import { ThemeProvider } from "./contexts/ThemeContext"
 
@@ -182,6 +185,36 @@ function App() {
                 <ProtectedRoute niveisPermitidos={["00", "06", "15", "80"]}>
                   <Layout>
                     <AutorizacaoCompraDetalhes />
+                  </Layout>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/controle-acesso/modulos"
+              element={
+                <ProtectedRoute niveisPermitidos={["00"]}>
+                  <Layout>
+                    <ControleAcessoModulos />
+                  </Layout>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/controle-acesso/niveis"
+              element={
+                <ProtectedRoute niveisPermitidos={["00"]}>
+                  <Layout>
+                    <ControleAcessoNiveis />
+                  </Layout>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/controle-acesso/permissoes"
+              element={
+                <ProtectedRoute niveisPermitidos={["00"]}>
+                  <Layout>
+                    <ControleAcessoPermissoes />
                   </Layout>
                 </ProtectedRoute>
               }

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -39,6 +39,10 @@ import {
   Person as PersonIcon,
   AccountBalance as ControladoriaIcon, // Ícone para Controladoria
   ShoppingCart as AutorizacaoIcon, // Ícone para Autorização Compra
+  Security as AcessoIcon,
+  Settings as ModulosIcon,
+  People as NiveisIcon,
+  VpnKey as PermissoesIcon,
 } from "@mui/icons-material"
 import { Link, useLocation, useNavigate } from "react-router-dom"
 import { useAuth } from "../contexts/AuthContext"
@@ -131,6 +135,15 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
       text: "Controladoria",
       icon: <ControladoriaIcon />,
       subItems: [{ text: "Autorização Compra", icon: <AutorizacaoIcon />, path: "/controladoria/autorizacao-compra" }],
+    },
+    {
+      text: "Controle de Acesso",
+      icon: <AcessoIcon />,
+      subItems: [
+        { text: "Módulos", icon: <ModulosIcon />, path: "/controle-acesso/modulos" },
+        { text: "Níveis", icon: <NiveisIcon />, path: "/controle-acesso/niveis" },
+        { text: "Permissões", icon: <PermissoesIcon />, path: "/controle-acesso/permissoes" },
+      ],
     },
   ]
 

--- a/frontend/src/pages/ControleAcessoModulos.tsx
+++ b/frontend/src/pages/ControleAcessoModulos.tsx
@@ -1,0 +1,130 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import {
+  Box,
+  Typography,
+  Paper,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  Button,
+  TextField,
+  Switch,
+  FormControlLabel,
+} from "@mui/material"
+import { useAuth } from "../contexts/AuthContext"
+import * as acessoService from "../services/controleAcessoService"
+import type { Modulo } from "../types"
+
+const ControleAcessoModulos: React.FC = () => {
+  const [modulos, setModulos] = useState<Modulo[]>([])
+  const [nome, setNome] = useState("")
+  const [rota, setRota] = useState("")
+  const [ativo, setAtivo] = useState(true)
+  const [editId, setEditId] = useState<number | null>(null)
+  const { temPermissao } = useAuth()
+  const podeEditar = temPermissao(["00"])
+
+  const carregar = async () => {
+    try {
+      const data = await acessoService.getModulos()
+      setModulos(data)
+    } catch (err) {
+      console.error("Erro ao carregar módulos", err)
+    }
+  }
+
+  useEffect(() => {
+    carregar()
+  }, [])
+
+  const limpar = () => {
+    setNome("")
+    setRota("")
+    setAtivo(true)
+    setEditId(null)
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    try {
+      if (editId) {
+        await acessoService.atualizarModulo(editId, { nome, rota, ativo })
+      } else {
+        await acessoService.criarModulo({ nome, rota, ativo })
+      }
+      limpar()
+      await carregar()
+    } catch (err) {
+      console.error("Erro ao salvar módulo", err)
+    }
+  }
+
+  const handleEditar = (m: Modulo) => {
+    setNome(m.nome)
+    setRota(m.rota)
+    setAtivo(m.ativo)
+    setEditId(m.id)
+  }
+
+  const handleExcluir = async (id: number) => {
+    if (!window.confirm("Excluir módulo?")) return
+    await acessoService.excluirModulo(id)
+    await carregar()
+  }
+
+  return (
+    <Box p={3}>
+      <Typography variant="h4" gutterBottom>Módulos</Typography>
+
+      {podeEditar && (
+        <Paper sx={{ p:2, mb:3 }}>
+          <form onSubmit={handleSubmit}>
+            <Box display="flex" flexDirection="column" gap={2}>
+              <TextField label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
+              <TextField label="Rota" value={rota} onChange={(e) => setRota(e.target.value)} required />
+              <FormControlLabel control={<Switch checked={ativo} onChange={(e) => setAtivo(e.target.checked)} />} label="Ativo" />
+              <Box>
+                <Button type="submit" variant="contained">{editId ? "Salvar" : "Criar"}</Button>
+                {editId && <Button sx={{ ml:2 }} onClick={limpar}>Cancelar</Button>}
+              </Box>
+            </Box>
+          </form>
+        </Paper>
+      )}
+
+      <Paper>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Nome</TableCell>
+              <TableCell>Rota</TableCell>
+              <TableCell>Ativo</TableCell>
+              {podeEditar && <TableCell>Ações</TableCell>}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {modulos.map((m) => (
+              <TableRow key={m.id}>
+                <TableCell>{m.nome}</TableCell>
+                <TableCell>{m.rota}</TableCell>
+                <TableCell>{m.ativo ? "Sim" : "Não"}</TableCell>
+                {podeEditar && (
+                  <TableCell>
+                    <Button onClick={() => handleEditar(m)}>Editar</Button>
+                    <Button onClick={() => handleExcluir(m.id)}>Excluir</Button>
+                  </TableCell>
+                )}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Paper>
+    </Box>
+  )
+}
+
+export default ControleAcessoModulos

--- a/frontend/src/pages/ControleAcessoNiveis.tsx
+++ b/frontend/src/pages/ControleAcessoNiveis.tsx
@@ -1,0 +1,132 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import {
+  Box,
+  Typography,
+  Paper,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  Button,
+  TextField,
+  Switch,
+  FormControlLabel,
+} from "@mui/material"
+import { useAuth } from "../contexts/AuthContext"
+import * as acessoService from "../services/controleAcessoService"
+import type { NivelAcesso } from "../types"
+
+const ControleAcessoNiveis: React.FC = () => {
+  const [niveis, setNiveis] = useState<NivelAcesso[]>([])
+  const [codigo, setCodigo] = useState("")
+  const [descricao, setDescricao] = useState("")
+  const [ativo, setAtivo] = useState(true)
+  const [editando, setEditando] = useState<string | null>(null)
+  const { temPermissao } = useAuth()
+  const podeEditar = temPermissao(["00"])
+
+  const carregar = async () => {
+    try {
+      const data = await acessoService.getNiveis()
+      setNiveis(data)
+    } catch (err) {
+      console.error("Erro ao carregar níveis", err)
+    }
+  }
+
+  useEffect(() => {
+    carregar()
+  }, [])
+
+  const limpar = () => {
+    setCodigo("")
+    setDescricao("")
+    setAtivo(true)
+    setEditando(null)
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    try {
+      if (editando) {
+        await acessoService.atualizarNivel(editando, { descricao, ativo })
+      } else {
+        await acessoService.criarNivel({ codigo, descricao, ativo })
+      }
+      limpar()
+      await carregar()
+    } catch (err) {
+      console.error("Erro ao salvar nível", err)
+    }
+  }
+
+  const handleEditar = (nivel: NivelAcesso) => {
+    setCodigo(nivel.codigo)
+    setDescricao(nivel.descricao)
+    setAtivo(nivel.ativo)
+    setEditando(nivel.codigo)
+  }
+
+  const handleExcluir = async (codigo: string) => {
+    if (!window.confirm("Excluir nível?")) return
+    await acessoService.excluirNivel(codigo)
+    await carregar()
+  }
+
+  return (
+    <Box p={3}>
+      <Typography variant="h4" gutterBottom>Níveis de Acesso</Typography>
+
+      {podeEditar && (
+        <Paper sx={{ p:2, mb:3 }}>
+          <form onSubmit={handleSubmit}>
+            <Box display="flex" flexDirection="column" gap={2}>
+              {!editando && (
+                <TextField label="Código" value={codigo} onChange={(e) => setCodigo(e.target.value)} required />
+              )}
+              <TextField label="Descrição" value={descricao} onChange={(e) => setDescricao(e.target.value)} required />
+              <FormControlLabel control={<Switch checked={ativo} onChange={(e) => setAtivo(e.target.checked)} />} label="Ativo" />
+              <Box>
+                <Button type="submit" variant="contained">{editando ? "Salvar" : "Criar"}</Button>
+                {editando && <Button sx={{ ml:2 }} onClick={limpar}>Cancelar</Button>}
+              </Box>
+            </Box>
+          </form>
+        </Paper>
+      )}
+
+      <Paper>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Código</TableCell>
+              <TableCell>Descrição</TableCell>
+              <TableCell>Ativo</TableCell>
+              {podeEditar && <TableCell>Ações</TableCell>}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {niveis.map((nivel) => (
+              <TableRow key={nivel.codigo}>
+                <TableCell>{nivel.codigo}</TableCell>
+                <TableCell>{nivel.descricao}</TableCell>
+                <TableCell>{nivel.ativo ? "Sim" : "Não"}</TableCell>
+                {podeEditar && (
+                  <TableCell>
+                    <Button onClick={() => handleEditar(nivel)}>Editar</Button>
+                    <Button onClick={() => handleExcluir(nivel.codigo)}>Excluir</Button>
+                  </TableCell>
+                )}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Paper>
+    </Box>
+  )
+}
+
+export default ControleAcessoNiveis

--- a/frontend/src/pages/ControleAcessoPermissoes.tsx
+++ b/frontend/src/pages/ControleAcessoPermissoes.tsx
@@ -1,0 +1,115 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import {
+  Box,
+  Typography,
+  Paper,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  Checkbox,
+  Button,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+} from "@mui/material"
+import { useAuth } from "../contexts/AuthContext"
+import * as acessoService from "../services/controleAcessoService"
+import type { NivelAcesso, Modulo, PermissaoNivel } from "../types"
+
+const ControleAcessoPermissoes: React.FC = () => {
+  const [niveis, setNiveis] = useState<NivelAcesso[]>([])
+  const [modulos, setModulos] = useState<Modulo[]>([])
+  const [nivelSel, setNivelSel] = useState<string>("")
+  const [permissoes, setPermissoes] = useState<Record<number, PermissaoNivel>>({})
+  const { temPermissao } = useAuth()
+  const podeEditar = temPermissao(["00"])
+
+  useEffect(() => {
+    const carregar = async () => {
+      setNiveis(await acessoService.getNiveis())
+      setModulos(await acessoService.getModulos())
+    }
+    carregar()
+  }, [])
+
+  useEffect(() => {
+    const carregarPerm = async () => {
+      if (!nivelSel) return
+      const lista = await acessoService.getPermissoes(nivelSel)
+      const map: Record<number, PermissaoNivel> = {}
+      lista.forEach((p) => { map[p.id_modulo] = p })
+      setPermissoes(map)
+    }
+    carregarPerm()
+  }, [nivelSel])
+
+  const handleChange = (id: number, campo: keyof PermissaoNivel, valor: boolean) => {
+    setPermissoes((prev) => ({
+      ...prev,
+      [id]: { ...prev[id], id_modulo: id, codigo_nivel: nivelSel, [campo]: valor },
+    }))
+  }
+
+  const handleSalvar = async () => {
+    const lista = Object.values(permissoes)
+    await acessoService.salvarPermissoes(nivelSel, lista)
+    alert("Permissões salvas")
+  }
+
+  return (
+    <Box p={3}>
+      <Typography variant="h4" gutterBottom>Permissões</Typography>
+
+      <FormControl fullWidth sx={{ mb:3 }}>
+        <InputLabel id="nivel-label">Nível</InputLabel>
+        <Select labelId="nivel-label" value={nivelSel} label="Nível" onChange={(e) => setNivelSel(e.target.value as string)}>
+          {niveis.map((n) => (
+            <MenuItem key={n.codigo} value={n.codigo}>{n.descricao}</MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+
+      {nivelSel && (
+        <Paper sx={{ p:2 }}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Módulo</TableCell>
+                <TableCell>Visualizar</TableCell>
+                <TableCell>Incluir</TableCell>
+                <TableCell>Editar</TableCell>
+                <TableCell>Excluir</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {modulos.map((m) => {
+                const p = permissoes[m.id] || { codigo_nivel: nivelSel, id_modulo: m.id, visualizar: false, incluir: false, editar: false, excluir: false }
+                return (
+                  <TableRow key={m.id}>
+                    <TableCell>{m.nome}</TableCell>
+                    <TableCell><Checkbox checked={p.visualizar} onChange={(e) => handleChange(m.id, "visualizar", e.target.checked)} /></TableCell>
+                    <TableCell><Checkbox checked={p.incluir} onChange={(e) => handleChange(m.id, "incluir", e.target.checked)} /></TableCell>
+                    <TableCell><Checkbox checked={p.editar} onChange={(e) => handleChange(m.id, "editar", e.target.checked)} /></TableCell>
+                    <TableCell><Checkbox checked={p.excluir} onChange={(e) => handleChange(m.id, "excluir", e.target.checked)} /></TableCell>
+                  </TableRow>
+                )
+              })}
+            </TableBody>
+          </Table>
+          {podeEditar && (
+            <Box mt={2}>
+              <Button variant="contained" onClick={handleSalvar}>Salvar</Button>
+            </Box>
+          )}
+        </Paper>
+      )}
+    </Box>
+  )
+}
+
+export default ControleAcessoPermissoes

--- a/frontend/src/services/controleAcessoService.ts
+++ b/frontend/src/services/controleAcessoService.ts
@@ -1,0 +1,49 @@
+import api from "./api"
+import type { Modulo, NivelAcesso, PermissaoNivel } from "../types"
+
+export const getModulos = async (): Promise<Modulo[]> => {
+  const response = await api.get("/controle-acesso/modulos")
+  return response.data
+}
+
+export const criarModulo = async (modulo: Omit<Modulo, "id">): Promise<Modulo> => {
+  const response = await api.post("/controle-acesso/modulos", modulo)
+  return response.data
+}
+
+export const atualizarModulo = async (id: number, modulo: Partial<Modulo>): Promise<Modulo> => {
+  const response = await api.put(`/controle-acesso/modulos/${id}`, modulo)
+  return response.data
+}
+
+export const excluirModulo = async (id: number): Promise<void> => {
+  await api.delete(`/controle-acesso/modulos/${id}`)
+}
+
+export const getNiveis = async (): Promise<NivelAcesso[]> => {
+  const response = await api.get("/controle-acesso/niveis")
+  return response.data
+}
+
+export const criarNivel = async (nivel: NivelAcesso): Promise<NivelAcesso> => {
+  const response = await api.post("/controle-acesso/niveis", nivel)
+  return response.data
+}
+
+export const atualizarNivel = async (codigo: string, nivel: Partial<NivelAcesso>): Promise<NivelAcesso> => {
+  const response = await api.put(`/controle-acesso/niveis/${codigo}`, nivel)
+  return response.data
+}
+
+export const excluirNivel = async (codigo: string): Promise<void> => {
+  await api.delete(`/controle-acesso/niveis/${codigo}`)
+}
+
+export const getPermissoes = async (codigo: string): Promise<PermissaoNivel[]> => {
+  const response = await api.get(`/controle-acesso/permissoes/${codigo}`)
+  return response.data
+}
+
+export const salvarPermissoes = async (codigo: string, permissoes: PermissaoNivel[]): Promise<void> => {
+  await api.put(`/controle-acesso/permissoes/${codigo}`, permissoes)
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -108,3 +108,28 @@ export interface AutorizacaoCompra {
   usuario_diretoria?: string
   liberada?: boolean
 }
+
+// Tipos para o módulo de Controle de Acesso
+export interface Modulo {
+  id: number
+  nome: string
+  rota: string
+  icone?: string
+  ordem?: number
+  ativo: boolean
+}
+
+export interface NivelAcesso {
+  codigo: string
+  descricao: string
+  ativo: boolean
+}
+
+export interface PermissaoNivel {
+  codigo_nivel: string
+  id_modulo: number
+  visualizar: boolean
+  incluir: boolean
+  editar: boolean
+  excluir: boolean
+}


### PR DESCRIPTION
## Summary
- expose access control pages in the menu
- implement pages for modules, access levels and permissions
- add frontend service and types for Controle de Acesso

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a8c5b50108324bd875188f2cc4dfe