### PR TITLE
Fix permissions save API input validation

### DIFF
--- a/backend/src/controllers/controleAcessoController.ts
+++ b/backend/src/controllers/controleAcessoController.ts
@@ -107,7 +107,12 @@ export const listarPermissoes = async (req: Request, res: Response): Promise<voi
 export const salvarPermissoes = async (req: Request, res: Response): Promise<void> => {
     try {
         const codigo = req.params.codigo
-        await acessoService.salvarPermissoesNivel(codigo, req.body)
+        const permissoes = Array.isArray(req.body) ? req.body : null
+        if (!permissoes) {
+            res.status(400).json({ error: "Formato de permissões inválido" })
+            return
+        }
+        await acessoService.salvarPermissoesNivel(codigo, permissoes)
         res.json({ message: "Permissões salvas" })
     } catch (error) {
         console.error("Erro ao salvar permissões:", error)


### PR DESCRIPTION
## Summary
- validate request body for saving permissions

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a904c26688324b923c9d63247ddae