### PR TITLE
Implement module-level permission checks

### DIFF
--- a/backend/src/routes/autorizacaoCompraRoutes.ts
+++ b/backend/src/routes/autorizacaoCompraRoutes.ts
@@ -1,31 +1,49 @@
 import { Router } from "express"
-import { verificarAutenticacao, verificarNivel } from "../middlewares/authMiddleware"
+import { verificarAutenticacao, verificarPermissao } from "../middlewares/authMiddleware"
 import * as autorizacaoCompraController from "../controllers/autorizacaoCompraController"
 
 const router = Router()
 
 // Rotas para autorização de compra
-router.post("/", verificarAutenticacao, autorizacaoCompraController.criarAutorizacao)
-router.get("/", verificarAutenticacao, autorizacaoCompraController.listarAutorizacoes)
-router.get("/:id", verificarAutenticacao, autorizacaoCompraController.obterAutorizacao)
+router.post(
+    "/",
+    verificarAutenticacao,
+    verificarPermissao("autorizacao-compra", "incluir"),
+    autorizacaoCompraController.criarAutorizacao,
+)
+router.get(
+    "/",
+    verificarAutenticacao,
+    autorizacaoCompraController.listarAutorizacoes,
+)
+router.get(
+    "/:id",
+    verificarAutenticacao,
+    autorizacaoCompraController.obterAutorizacao,
+)
 router.put(
     "/:id/autorizar-controladoria",
     verificarAutenticacao,
-    verificarNivel(["06"]),
+    verificarPermissao("autorizacao-compra", "editar"),
     autorizacaoCompraController.autorizarControladoria,
 )
 router.put(
     "/:id/reverter-controladoria",
     verificarAutenticacao,
-    verificarNivel(["06"]),
+    verificarPermissao("autorizacao-compra", "editar"),
     autorizacaoCompraController.reverterControladoria,
 )
 router.put(
     "/:id/autorizar-diretoria",
     verificarAutenticacao,
-    verificarNivel(["00"]),
+    verificarPermissao("autorizacao-compra", "editar"),
     autorizacaoCompraController.autorizarDiretoria,
 )
-router.delete("/:id", verificarAutenticacao, autorizacaoCompraController.excluirAutorizacao)
+router.delete(
+    "/:id",
+    verificarAutenticacao,
+    verificarPermissao("autorizacao-compra", "excluir"),
+    autorizacaoCompraController.excluirAutorizacao,
+)
 
 export default router

--- a/backend/src/routes/comissaoRoutes.ts
+++ b/backend/src/routes/comissaoRoutes.ts
@@ -1,6 +1,6 @@
 import { Router } from "express"
 import * as comissaoController from "../controllers/comissaoController"
-import { verificarAutenticacao, verificarNivel } from "../middlewares/authMiddleware"
+import { verificarAutenticacao, verificarPermissao } from "../middlewares/authMiddleware"
 
 const router = Router()
 
@@ -12,9 +12,21 @@ router.get("/", comissaoController.getFaixasComissao)
 router.get("/:id", comissaoController.getFaixaComissao)
 
 // Rotas que requerem nível específico
-router.post("/", verificarNivel(["00"]), comissaoController.criarFaixaComissao)
-router.put("/:id", verificarNivel(["00"]), comissaoController.atualizarFaixaComissao)
-router.delete("/:id", verificarNivel(["00"]), comissaoController.excluirFaixaComissao)
-router.delete("/percentual/:id", verificarNivel(["00"]), comissaoController.excluirPercentual)
+router.post("/", verificarPermissao("comissoes", "incluir"), comissaoController.criarFaixaComissao)
+router.put(
+    "/:id",
+    verificarPermissao("comissoes", "editar"),
+    comissaoController.atualizarFaixaComissao,
+)
+router.delete(
+    "/:id",
+    verificarPermissao("comissoes", "excluir"),
+    comissaoController.excluirFaixaComissao,
+)
+router.delete(
+    "/percentual/:id",
+    verificarPermissao("comissoes", "excluir"),
+    comissaoController.excluirPercentual,
+)
 
 export default router

--- a/backend/src/routes/controleAcessoRoutes.ts
+++ b/backend/src/routes/controleAcessoRoutes.ts
@@ -1,5 +1,5 @@
 import { Router } from "express"
-import { verificarAutenticacao, verificarNivel } from "../middlewares/authMiddleware"
+import { verificarAutenticacao, verificarPermissao } from "../middlewares/authMiddleware"
 import * as controleAcessoController from "../controllers/controleAcessoController"
 
 const router = Router()
@@ -7,16 +7,40 @@ const router = Router()
 router.use(verificarAutenticacao)
 
 router.get("/modulos", controleAcessoController.listarModulos)
-router.post("/modulos", verificarNivel(["00"]), controleAcessoController.criarModulo)
-router.put("/modulos/:id", verificarNivel(["00"]), controleAcessoController.atualizarModulo)
-router.delete("/modulos/:id", verificarNivel(["00"]), controleAcessoController.excluirModulo)
+router.post("/modulos", verificarPermissao("controle-acesso", "incluir"), controleAcessoController.criarModulo)
+router.put(
+    "/modulos/:id",
+    verificarPermissao("controle-acesso", "editar"),
+    controleAcessoController.atualizarModulo,
+)
+router.delete(
+    "/modulos/:id",
+    verificarPermissao("controle-acesso", "excluir"),
+    controleAcessoController.excluirModulo,
+)
 
 router.get("/niveis", controleAcessoController.listarNiveis)
-router.post("/niveis", verificarNivel(["00"]), controleAcessoController.criarNivel)
-router.put("/niveis/:codigo", verificarNivel(["00"]), controleAcessoController.atualizarNivel)
-router.delete("/niveis/:codigo", verificarNivel(["00"]), controleAcessoController.excluirNivel)
+router.post(
+    "/niveis",
+    verificarPermissao("controle-acesso", "incluir"),
+    controleAcessoController.criarNivel,
+)
+router.put(
+    "/niveis/:codigo",
+    verificarPermissao("controle-acesso", "editar"),
+    controleAcessoController.atualizarNivel,
+)
+router.delete(
+    "/niveis/:codigo",
+    verificarPermissao("controle-acesso", "excluir"),
+    controleAcessoController.excluirNivel,
+)
 
 router.get("/permissoes/:codigo", controleAcessoController.listarPermissoes)
-router.put("/permissoes/:codigo", verificarNivel(["00"]), controleAcessoController.salvarPermissoes)
+router.put(
+    "/permissoes/:codigo",
+    verificarPermissao("controle-acesso", "editar"),
+    controleAcessoController.salvarPermissoes,
+)
 
 export default router

--- a/backend/src/routes/produtoRoutes.ts
+++ b/backend/src/routes/produtoRoutes.ts
@@ -1,6 +1,6 @@
 import { Router } from "express"
 import * as produtoController from "../controllers/produtoController"
-import { verificarAutenticacao, verificarNivel } from "../middlewares/authMiddleware"
+import { verificarAutenticacao, verificarPermissao } from "../middlewares/authMiddleware"
 
 const router = Router()
 
@@ -13,11 +13,27 @@ router.get("/etiquetas", produtoController.getProdutosEtiquetas)
 router.get("/buscar", produtoController.buscarProdutos)
 
 // Rotas que requerem nível específico
-router.post("/fora", verificarNivel(["00", "15"]), produtoController.adicionarProdutoFora)
-router.delete("/fora/:codproduto/:mesAno", verificarNivel(["00", "15"]), produtoController.removerProdutoFora)
-router.post("/etiqueta", verificarNivel(["00", "15"]), produtoController.adicionarProdutoBandeira)
-router.delete("/etiqueta/:codproduto/:mesAno", verificarNivel(["00", "15"]), produtoController.removerProdutoBandeira)
-router.post("/fora/importar", verificarNivel(["00"]), produtoController.importarProdutosFora)
-router.post("/etiqueta/importar", verificarNivel(["00"]), produtoController.importarProdutosEtiquetas)
+router.post("/fora", verificarPermissao("produtos", "incluir"), produtoController.adicionarProdutoFora)
+router.delete(
+    "/fora/:codproduto/:mesAno",
+    verificarPermissao("produtos", "excluir"),
+    produtoController.removerProdutoFora,
+)
+router.post("/etiqueta", verificarPermissao("produtos", "incluir"), produtoController.adicionarProdutoBandeira)
+router.delete(
+    "/etiqueta/:codproduto/:mesAno",
+    verificarPermissao("produtos", "excluir"),
+    produtoController.removerProdutoBandeira,
+)
+router.post(
+    "/fora/importar",
+    verificarPermissao("produtos", "incluir"),
+    produtoController.importarProdutosFora,
+)
+router.post(
+    "/etiqueta/importar",
+    verificarPermissao("produtos", "incluir"),
+    produtoController.importarProdutosEtiquetas,
+)
 
 export default router

--- a/backend/src/routes/promocaoRoutes.ts
+++ b/backend/src/routes/promocaoRoutes.ts
@@ -1,6 +1,6 @@
 import { Router } from "express"
 import * as promocaoController from "../controllers/promocaoController"
-import { verificarAutenticacao, verificarNivel } from "../middlewares/authMiddleware"
+import { verificarAutenticacao, verificarPermissao } from "../middlewares/authMiddleware"
 
 const router = Router()
 
@@ -12,6 +12,10 @@ router.get("/", promocaoController.getProdutosPromocao)
 router.get("/buscar", promocaoController.buscarProdutosPromocao)
 
 // Rota para importação (apenas níveis específicos)
-router.post("/importar", verificarNivel(["00", "15"]), promocaoController.importarProdutosPromocao)
+router.post(
+    "/importar",
+    verificarPermissao("promocoes", "incluir"),
+    promocaoController.importarProdutosPromocao,
+)
 
 export default router

--- a/backend/src/routes/vendedorMetaRoutes.ts
+++ b/backend/src/routes/vendedorMetaRoutes.ts
@@ -1,6 +1,6 @@
 import express from "express"
 import * as vendedorMetaController from "../controllers/vendedorMetaController"
-import { verificarAutenticacao, verificarNivel } from "../middlewares/authMiddleware"
+import { verificarAutenticacao, verificarPermissao } from "../middlewares/authMiddleware"
 
 const router = express.Router()
 
@@ -18,6 +18,11 @@ router.delete("/:codvendedor/:competencia", verificarAutenticacao, vendedorMetaC
 router.post("/copiar", verificarAutenticacao, vendedorMetaController.copiarMetas)
 
 // Rota para importar metas em lote
-router.post("/importar", verificarAutenticacao, verificarNivel(["00", "15"]), vendedorMetaController.importarMetas)
+router.post(
+    "/importar",
+    verificarAutenticacao,
+    verificarPermissao("vendedor-metas", "incluir"),
+    vendedorMetaController.importarMetas,
+)
 
 export default router

--- a/backend/src/services/controleAcessoService.ts
+++ b/backend/src/services/controleAcessoService.ts
@@ -180,3 +180,22 @@ export const salvarPermissoesNivel = async (
         client.release()
     }
 }
+
+export const verificarPermissaoModulo = async (
+    codigo: string,
+    rota: string,
+    acao: "visualizar" | "incluir" | "editar" | "excluir",
+): Promise<boolean> => {
+    const query = `
+        SELECT p.visualizar, p.incluir, p.editar, p.excluir
+        FROM scc_permissoes_nivel p
+        JOIN scc_modulos m ON m.id = p.id_modulo
+        WHERE p.codigo_nivel = $1 AND m.rota = $2
+    `
+    const result = await pool.query(query, [codigo, rota])
+    if (result.rows.length === 0) {
+        return false
+    }
+    const permissao = result.rows[0] as PermissaoNivel
+    return Boolean(permissao[acao])
+}


### PR DESCRIPTION
## Summary
- expand access control service with `verificarPermissaoModulo`
- add new `verificarPermissao` middleware
- apply permission checks across all route modules

## Testing
- `npm run build` *(fails: cannot find module dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685a96ef268c8324a788c1cc3af4b781