### PR TITLE
Fix frontend module permission checks

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,7 +51,7 @@ function App() {
             <Route
               path="/produtos-fora"
               element={
-                <ProtectedRoute rota="/produtos-fora">
+                <ProtectedRoute rota="produtos">
                   <Layout>
                     <ProdutosFora />
                   </Layout>
@@ -61,7 +61,7 @@ function App() {
             <Route
               path="/produtos-etiquetas"
               element={
-                <ProtectedRoute rota="/produtos-etiquetas">
+                <ProtectedRoute rota="produtos">
                   <Layout>
                     <ProdutosEtiquetas />
                   </Layout>
@@ -71,7 +71,7 @@ function App() {
             <Route
               path="/promocao"
               element={
-                <ProtectedRoute rota="/promocao">
+                <ProtectedRoute rota="promocoes">
                   <Layout>
                     <ProdutosPromocao />
                   </Layout>
@@ -82,7 +82,7 @@ function App() {
             <Route
               path="/precificacao"
               element={
-                <ProtectedRoute rota="/precificacao">
+                <ProtectedRoute rota="produtos">
                   <Layout>
                     <Precificacao />
                   </Layout>
@@ -92,7 +92,7 @@ function App() {
             <Route
               path="/comissao/faixas"
               element={
-                <ProtectedRoute rota="/comissao/faixas">
+                <ProtectedRoute rota="comissoes">
                   <Layout>
                     <ComissaoFaixas />
                   </Layout>
@@ -102,7 +102,7 @@ function App() {
             <Route
               path="/comissao/faixas/nova"
               element={
-                <ProtectedRoute rota="/comissao/faixas">
+                <ProtectedRoute rota="comissoes">
                   <Layout>
                     <ComissaoFormulario />
                   </Layout>
@@ -112,7 +112,7 @@ function App() {
             <Route
               path="/comissao/faixas/editar/:id"
               element={
-                <ProtectedRoute rota="/comissao/faixas">
+                <ProtectedRoute rota="comissoes">
                   <Layout>
                     <ComissaoFormulario />
                   </Layout>
@@ -122,7 +122,7 @@ function App() {
             <Route
               path="/comissao/metas"
               element={
-                <ProtectedRoute rota="/comissao/metas">
+                <ProtectedRoute rota="vendedor-metas">
                   <Layout>
                     <VendedorMetas />
                   </Layout>
@@ -132,7 +132,7 @@ function App() {
             <Route
               path="/comissao/metas/nova"
               element={
-                <ProtectedRoute rota="/comissao/metas">
+                <ProtectedRoute rota="vendedor-metas">
                   <Layout>
                     <VendedorMetaFormulario />
                   </Layout>
@@ -142,7 +142,7 @@ function App() {
             <Route
               path="/comissao/metas/editar/:codvendedor"
               element={
-                <ProtectedRoute rota="/comissao/metas">
+                <ProtectedRoute rota="vendedor-metas">
                   <Layout>
                     <VendedorMetaFormulario />
                   </Layout>
@@ -152,7 +152,7 @@ function App() {
             <Route
               path="/controladoria/autorizacao-compra"
               element={
-                <ProtectedRoute rota="/controladoria/autorizacao-compra">
+                <ProtectedRoute rota="autorizacao-compra">
                   <Layout>
                     <AutorizacaoCompraPage />
                   </Layout>
@@ -162,7 +162,7 @@ function App() {
             <Route
               path="/controladoria/autorizacao-compra/novo"
               element={
-                <ProtectedRoute rota="/controladoria/autorizacao-compra">
+                <ProtectedRoute rota="autorizacao-compra">
                   <Layout>
                     <AutorizacaoCompraFormulario />
                   </Layout>
@@ -172,7 +172,7 @@ function App() {
             <Route
               path="/controladoria/autorizacao-compra/editar/:id"
               element={
-                <ProtectedRoute rota="/controladoria/autorizacao-compra">
+                <ProtectedRoute rota="autorizacao-compra">
                   <Layout>
                     <AutorizacaoCompraFormulario />
                   </Layout>
@@ -182,7 +182,7 @@ function App() {
             <Route
               path="/controladoria/autorizacao-compra/visualizar/:id"
               element={
-                <ProtectedRoute rota="/controladoria/autorizacao-compra">
+                <ProtectedRoute rota="autorizacao-compra">
                   <Layout>
                     <AutorizacaoCompraDetalhes />
                   </Layout>
@@ -192,7 +192,7 @@ function App() {
             <Route
               path="/controle-acesso/modulos"
               element={
-                <ProtectedRoute rota="/controle-acesso/modulos">
+                <ProtectedRoute rota="controle-acesso">
                   <Layout>
                     <ControleAcessoModulos />
                   </Layout>
@@ -202,7 +202,7 @@ function App() {
             <Route
               path="/controle-acesso/niveis"
               element={
-                <ProtectedRoute rota="/controle-acesso/niveis">
+                <ProtectedRoute rota="controle-acesso">
                   <Layout>
                     <ControleAcessoNiveis />
                   </Layout>
@@ -212,7 +212,7 @@ function App() {
             <Route
               path="/controle-acesso/permissoes"
               element={
-                <ProtectedRoute rota="/controle-acesso/permissoes">
+                <ProtectedRoute rota="controle-acesso">
                   <Layout>
                     <ControleAcessoPermissoes />
                   </Layout>

--- a/frontend/src/pages/ComissaoFaixas.tsx
+++ b/frontend/src/pages/ComissaoFaixas.tsx
@@ -74,8 +74,8 @@ const ComissaoFaixas: React.FC = () => {
     const [filtroAberto, setFiltroAberto] = useState(false)
 
     const navigate = useNavigate()
-    const { temPermissao } = useAuth()
-    const podeEditar = temPermissao(["00"])
+    const { temPermissaoModulo } = useAuth()
+    const podeEditar = temPermissaoModulo("comissoes", "editar")
 
     // Carregar faixas ao montar o componente
     useEffect(() => {

--- a/frontend/src/pages/ControleAcessoModulos.tsx
+++ b/frontend/src/pages/ControleAcessoModulos.tsx
@@ -25,8 +25,8 @@ const ControleAcessoModulos: React.FC = () => {
   const [rota, setRota] = useState("")
   const [ativo, setAtivo] = useState(true)
   const [editId, setEditId] = useState<number | null>(null)
-  const { temPermissao } = useAuth()
-  const podeEditar = temPermissao(["00"])
+  const { temPermissaoModulo } = useAuth()
+  const podeEditar = temPermissaoModulo("controle-acesso", "editar")
 
   const carregar = async () => {
     try {

--- a/frontend/src/pages/ControleAcessoNiveis.tsx
+++ b/frontend/src/pages/ControleAcessoNiveis.tsx
@@ -25,8 +25,8 @@ const ControleAcessoNiveis: React.FC = () => {
   const [descricao, setDescricao] = useState("")
   const [ativo, setAtivo] = useState(true)
   const [editando, setEditando] = useState<string | null>(null)
-  const { temPermissao } = useAuth()
-  const podeEditar = temPermissao(["00"])
+  const { temPermissaoModulo } = useAuth()
+  const podeEditar = temPermissaoModulo("controle-acesso", "editar")
 
   const carregar = async () => {
     try {

--- a/frontend/src/pages/ControleAcessoPermissoes.tsx
+++ b/frontend/src/pages/ControleAcessoPermissoes.tsx
@@ -26,8 +26,8 @@ const ControleAcessoPermissoes: React.FC = () => {
   const [modulos, setModulos] = useState<Modulo[]>([])
   const [nivelSel, setNivelSel] = useState<string>("")
   const [permissoes, setPermissoes] = useState<Record<number, PermissaoNivel>>({})
-  const { temPermissao } = useAuth()
-  const podeEditar = temPermissao(["00"])
+  const { temPermissaoModulo } = useAuth()
+  const podeEditar = temPermissaoModulo("controle-acesso", "editar")
 
   useEffect(() => {
     const carregar = async () => {

--- a/frontend/src/pages/VendedorMetas.tsx
+++ b/frontend/src/pages/VendedorMetas.tsx
@@ -66,8 +66,8 @@ const VendedorMetas: React.FC = () => {
     const [dialogoImportacaoAberto, setDialogoImportacaoAberto] = useState(false)
 
     const navigate = useNavigate()
-    const { temPermissao } = useAuth()
-    const podeEditar = temPermissao(["00"])
+    const { temPermissaoModulo } = useAuth()
+    const podeEditar = temPermissaoModulo("vendedor-metas", "editar")
 
     // Carregar metas ao montar o componente ou quando a competência mudar
     useEffect(() => {


### PR DESCRIPTION
## Summary
- check module permissions on several pages using `temPermissaoModulo`
- pass backend module names to `ProtectedRoute`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a9e080b6c8324b55f7807166d3477