### PR TITLE
Implement pending board indicator

### DIFF
--- a/frontend/src/pages/AutorizacaoCompra.tsx
+++ b/frontend/src/pages/AutorizacaoCompra.tsx
@@ -209,7 +209,6 @@ const AutorizacaoCompraPage: React.FC = () => {
                 />,
             )
         }
-
         if (autorizacao.autorizado_diretoria) {
             chips.push(
                 <Tooltip
@@ -220,6 +219,16 @@ const AutorizacaoCompraPage: React.FC = () => {
                 >
                     <Chip label="Liberado Diretoria" color="success" size="small" />
                 </Tooltip>,
+            )
+        } else if (autorizacao.autorizado_controladoria) {
+            chips.push(
+                <Chip
+                    key="aguarda_dir"
+                    label="Aguardando Diretoria"
+                    color="warning"
+                    size="small"
+                    sx={{ mr: 0.5 }}
+                />,
             )
         }
 

--- a/frontend/src/pages/AutorizacaoCompraDetalhes.tsx
+++ b/frontend/src/pages/AutorizacaoCompraDetalhes.tsx
@@ -107,6 +107,8 @@ const AutorizacaoCompraDetalhes: React.FC = () => {
                     {" "}
                     {autorizacao.autorizado_diretoria
                         ? `Liberado em ${formatarData(autorizacao.data_autorizacao_diretoria || "")} por ${autorizacao.usuario_diretoria}`
+                        : autorizacao.autorizado_controladoria
+                        ? "Aguardando Diretoria"
                         : "Aguardando"}
                 </Typography>
             </Paper>


### PR DESCRIPTION
## Summary
- show **Aguardando Diretoria** chip when waiting for board approval
- display "Aguardando Diretoria" in details page once Controladoria approves

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aaf25c6e083248be67425ca6203e5