### PR TITLE
Add modal messages for CRUD and access

### DIFF
--- a/frontend/src/components/InfoDialog.tsx
+++ b/frontend/src/components/InfoDialog.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import React from "react"
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Typography } from "@mui/material"
+
+interface InfoDialogProps {
+    open: boolean
+    onClose: () => void
+    title?: string
+    message?: string
+}
+
+const InfoDialog: React.FC<InfoDialogProps> = ({ open, onClose, title = "Aviso", message }) => {
+    return (
+        <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+            <DialogTitle>{title}</DialogTitle>
+            <DialogContent>
+                <Typography>{message}</Typography>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose} variant="contained" autoFocus>
+                    OK
+                </Button>
+            </DialogActions>
+        </Dialog>
+    )
+}
+
+export default InfoDialog

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -3,6 +3,8 @@
 import type React from "react"
 import { Navigate } from "react-router-dom"
 import { useAuth } from "../contexts/AuthContext"
+import { useState } from "react"
+import InfoDialog from "./InfoDialog"
 
 interface ProtectedRouteProps {
     children: React.ReactNode
@@ -13,6 +15,7 @@ interface ProtectedRouteProps {
 
 const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children, niveisPermitidos, rota, acao = "visualizar" }) => {
     const { isAuthenticated, loading, temPermissao, temPermissaoModulo, usuario } = useAuth()
+    const [semPermissao, setSemPermissao] = useState(false)
 
     console.log("ProtectedRoute renderizando", {
         isAuthenticated,
@@ -36,13 +39,31 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children, niveisPermiti
     }
 
     if (rota && !temPermissaoModulo(rota, acao)) {
-        console.log("ProtectedRoute: Sem permissão módulo, redirecionando para /home")
-        return <Navigate to="/home" replace />
+        console.log("ProtectedRoute: Sem permissão módulo")
+        return (
+            <>
+                <InfoDialog
+                    open={!semPermissao}
+                    onClose={() => setSemPermissao(true)}
+                    title="Acesso negado"
+                    message="Você não tem permissão para acessar este módulo." />
+                {semPermissao && <Navigate to="/home" replace />}
+            </>
+        )
     }
 
     if (niveisPermitidos && niveisPermitidos.length > 0 && !temPermissao(niveisPermitidos)) {
-        console.log("ProtectedRoute: Sem permissão, redirecionando para /home")
-        return <Navigate to="/home" replace />
+        console.log("ProtectedRoute: Sem permissão de nível")
+        return (
+            <>
+                <InfoDialog
+                    open={!semPermissao}
+                    onClose={() => setSemPermissao(true)}
+                    title="Acesso negado"
+                    message="Você não tem permissão para acessar esta página." />
+                {semPermissao && <Navigate to="/home" replace />}
+            </>
+        )
     }
 
     console.log("ProtectedRoute: Renderizando children")

--- a/frontend/src/pages/ControleAcessoModulos.tsx
+++ b/frontend/src/pages/ControleAcessoModulos.tsx
@@ -15,6 +15,8 @@ import {
   Switch,
   FormControlLabel,
 } from "@mui/material"
+import ConfirmacaoExclusao from "../components/ConfirmacaoExclusao"
+import InfoDialog from "../components/InfoDialog"
 import { useAuth } from "../contexts/AuthContext"
 import * as acessoService from "../services/controleAcessoService"
 import type { Modulo } from "../types"
@@ -25,6 +27,8 @@ const ControleAcessoModulos: React.FC = () => {
   const [rota, setRota] = useState("")
   const [ativo, setAtivo] = useState(true)
   const [editId, setEditId] = useState<number | null>(null)
+  const [confirmacaoExclusao, setConfirmacaoExclusao] = useState<{open:boolean,id?:number}>({open:false})
+  const [sucesso, setSucesso] = useState(false)
   const { temPermissaoModulo } = useAuth()
   const podeEditar = temPermissaoModulo("controle-acesso", "editar")
 
@@ -58,6 +62,7 @@ const ControleAcessoModulos: React.FC = () => {
       }
       limpar()
       await carregar()
+      setSucesso(true)
     } catch (err) {
       console.error("Erro ao salvar módulo", err)
     }
@@ -70,9 +75,14 @@ const ControleAcessoModulos: React.FC = () => {
     setEditId(m.id)
   }
 
-  const handleExcluir = async (id: number) => {
-    if (!window.confirm("Excluir módulo?")) return
-    await acessoService.excluirModulo(id)
+  const handleExcluir = (id: number) => {
+    setConfirmacaoExclusao({ open: true, id })
+  }
+
+  const confirmarExclusao = async () => {
+    if (!confirmacaoExclusao.id) return
+    await acessoService.excluirModulo(confirmacaoExclusao.id)
+    setConfirmacaoExclusao({ open: false })
     await carregar()
   }
 
@@ -123,6 +133,18 @@ const ControleAcessoModulos: React.FC = () => {
           </TableBody>
         </Table>
       </Paper>
+      <ConfirmacaoExclusao
+        open={confirmacaoExclusao.open}
+        onClose={() => setConfirmacaoExclusao({ open: false })}
+        onConfirm={confirmarExclusao}
+        itemNome="módulo"
+      />
+      <InfoDialog
+        open={sucesso}
+        onClose={() => setSucesso(false)}
+        title="Sucesso"
+        message="Registro salvo com sucesso"
+      />
     </Box>
   )
 }

--- a/frontend/src/pages/ControleAcessoNiveis.tsx
+++ b/frontend/src/pages/ControleAcessoNiveis.tsx
@@ -15,6 +15,8 @@ import {
   Switch,
   FormControlLabel,
 } from "@mui/material"
+import ConfirmacaoExclusao from "../components/ConfirmacaoExclusao"
+import InfoDialog from "../components/InfoDialog"
 import { useAuth } from "../contexts/AuthContext"
 import * as acessoService from "../services/controleAcessoService"
 import type { NivelAcesso } from "../types"
@@ -25,6 +27,8 @@ const ControleAcessoNiveis: React.FC = () => {
   const [descricao, setDescricao] = useState("")
   const [ativo, setAtivo] = useState(true)
   const [editando, setEditando] = useState<string | null>(null)
+  const [confirmacaoExclusao, setConfirmacaoExclusao] = useState<{open:boolean,codigo?:string}>({open:false})
+  const [sucesso, setSucesso] = useState(false)
   const { temPermissaoModulo } = useAuth()
   const podeEditar = temPermissaoModulo("controle-acesso", "editar")
 
@@ -58,6 +62,7 @@ const ControleAcessoNiveis: React.FC = () => {
       }
       limpar()
       await carregar()
+      setSucesso(true)
     } catch (err) {
       console.error("Erro ao salvar nível", err)
     }
@@ -70,9 +75,14 @@ const ControleAcessoNiveis: React.FC = () => {
     setEditando(nivel.codigo)
   }
 
-  const handleExcluir = async (codigo: string) => {
-    if (!window.confirm("Excluir nível?")) return
-    await acessoService.excluirNivel(codigo)
+  const handleExcluir = (codigo: string) => {
+    setConfirmacaoExclusao({ open: true, codigo })
+  }
+
+  const confirmarExclusao = async () => {
+    if (!confirmacaoExclusao.codigo) return
+    await acessoService.excluirNivel(confirmacaoExclusao.codigo)
+    setConfirmacaoExclusao({ open: false })
     await carregar()
   }
 
@@ -125,6 +135,18 @@ const ControleAcessoNiveis: React.FC = () => {
           </TableBody>
         </Table>
       </Paper>
+      <ConfirmacaoExclusao
+        open={confirmacaoExclusao.open}
+        onClose={() => setConfirmacaoExclusao({ open: false })}
+        onConfirm={confirmarExclusao}
+        itemNome="nível"
+      />
+      <InfoDialog
+        open={sucesso}
+        onClose={() => setSucesso(false)}
+        title="Sucesso"
+        message="Registro salvo com sucesso"
+      />
     </Box>
   )
 }

--- a/frontend/src/pages/ControleAcessoPermissoes.tsx
+++ b/frontend/src/pages/ControleAcessoPermissoes.tsx
@@ -17,6 +17,7 @@ import {
   Select,
   MenuItem,
 } from "@mui/material"
+import InfoDialog from "../components/InfoDialog"
 import { useAuth } from "../contexts/AuthContext"
 import * as acessoService from "../services/controleAcessoService"
 import type { NivelAcesso, Modulo, PermissaoNivel } from "../types"
@@ -26,6 +27,7 @@ const ControleAcessoPermissoes: React.FC = () => {
   const [modulos, setModulos] = useState<Modulo[]>([])
   const [nivelSel, setNivelSel] = useState<string>("")
   const [permissoes, setPermissoes] = useState<Record<number, PermissaoNivel>>({})
+  const [sucesso, setSucesso] = useState(false)
   const { temPermissaoModulo } = useAuth()
   const podeEditar = temPermissaoModulo("controle-acesso", "editar")
 
@@ -58,7 +60,7 @@ const ControleAcessoPermissoes: React.FC = () => {
   const handleSalvar = async () => {
     const lista = Object.values(permissoes)
     await acessoService.salvarPermissoes(nivelSel, lista)
-    alert("Permissões salvas")
+    setSucesso(true)
   }
 
   return (
@@ -108,6 +110,12 @@ const ControleAcessoPermissoes: React.FC = () => {
           )}
         </Paper>
       )}
+      <InfoDialog
+        open={sucesso}
+        onClose={() => setSucesso(false)}
+        title="Sucesso"
+        message="Permissões salvas com sucesso"
+      />
     </Box>
   )
 }


### PR DESCRIPTION
## Summary
- add reusable `InfoDialog` component for simple modal messages
- enhance ProtectedRoute to show modal when user lacks permission
- use `InfoDialog` and `ConfirmacaoExclusao` in access control pages

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*
- `npx tsc -p frontend/tsconfig.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685abf8912188324ba0aa2a2a318829b