### PR TITLE
Add LOJAS constant for purchase form select

### DIFF
--- a/frontend/src/pages/AutorizacaoCompraFormulario.tsx
+++ b/frontend/src/pages/AutorizacaoCompraFormulario.tsx
@@ -9,6 +9,7 @@ import ArrowBackIcon from "@mui/icons-material/ArrowBack"
 import { useAuth } from "../contexts/AuthContext"
 import * as autorizacaoCompraService from "../services/autorizacaoCompraService"
 import type { AutorizacaoCompra } from "../types"
+import { LOJAS } from "../utils/lojas"
 
 const AutorizacaoCompraFormulario: React.FC = () => {
     const navigate = useNavigate()
@@ -22,25 +23,7 @@ const AutorizacaoCompraFormulario: React.FC = () => {
         severity: "success" as "success" | "error",
     })
 
-    const opcoesLojas = [
-        "LOURIVAL",
-        "KENNEDY",
-        "DIRCEU",
-        "PREMIUM",
-        "PARNAIBA",
-        "TANCREDO",
-        "PIÇARRA",
-        "TIMON",
-        "CD",
-        "BLACK",
-        "PICOS",
-        "PREM.PHB",
-        "CIMENTO",
-        "E-COMMERCE",
-        "ATACADO",
-        "LIGHT",
-        "CPTH",
-    ]
+    const opcoesLojas = LOJAS
 
     const isEdicao = !!id
 

--- a/frontend/src/utils/lojas.ts
+++ b/frontend/src/utils/lojas.ts
@@ -1,0 +1,21 @@
+export const LOJAS = [
+    "LOURIVAL",
+    "KENNEDY",
+    "DIRCEU",
+    "PREMIUM",
+    "PARNAIBA",
+    "TANCREDO",
+    "PIÇARRA",
+    "TIMON",
+    "CD",
+    "BLACK",
+    "PICOS",
+    "PREM.PHB",
+    "CIMENTO",
+    "E-COMMERCE",
+    "ATACADO",
+    "LIGHT",
+    "CPTH",
+] as const
+
+export type Loja = typeof LOJAS[number]


### PR DESCRIPTION
## Summary
- centralize store options in a new `LOJAS` constant
- use the constant in `AutorizacaoCompraFormulario`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685acaa1922083249afdf63333db8530