### PR TITLE
Add setor dropdown

### DIFF
--- a/frontend/src/pages/AutorizacaoCompraFormulario.tsx
+++ b/frontend/src/pages/AutorizacaoCompraFormulario.tsx
@@ -10,6 +10,7 @@ import { useAuth } from "../contexts/AuthContext"
 import * as autorizacaoCompraService from "../services/autorizacaoCompraService"
 import type { AutorizacaoCompra } from "../types"
 import { LOJAS } from "../utils/lojas"
+import { SETORES } from "../utils/setores"
 
 const AutorizacaoCompraFormulario: React.FC = () => {
     const navigate = useNavigate()
@@ -24,6 +25,7 @@ const AutorizacaoCompraFormulario: React.FC = () => {
     })
 
     const opcoesLojas = LOJAS
+    const opcoesSetores = SETORES
 
     const isEdicao = !!id
 
@@ -224,6 +226,7 @@ const AutorizacaoCompraFormulario: React.FC = () => {
                         </Grid>
                         <Grid item xs={12} md={6}>
                             <TextField
+                                select
                                 fullWidth
                                 label="Setor"
                                 name="setor"
@@ -233,7 +236,13 @@ const AutorizacaoCompraFormulario: React.FC = () => {
                                 helperText={formErrors.setor}
                                 disabled={loading}
                                 required
-                            />
+                            >
+                                {opcoesSetores.map((setor) => (
+                                    <MenuItem key={setor} value={setor}>
+                                        {setor}
+                                    </MenuItem>
+                                ))}
+                            </TextField>
                         </Grid>
                         <Grid item xs={12}>
                             <TextField

--- a/frontend/src/utils/setores.ts
+++ b/frontend/src/utils/setores.ts
@@ -1,0 +1,20 @@
+export const SETORES = [
+    "VENDA",
+    "CAIXA",
+    "DEPOSITO",
+    "TRANSPOTADORA",
+    "EXPEDIÇÂO",
+    "RH",
+    "CREDITO",
+    "FINANCEIRO",
+    "DIRETORIA",
+    "COMPRAS",
+    "TI",
+    "CONTROLADORIA",
+    "CONTABILIDADE",
+    "MARKETING",
+    "SAC",
+    "RECEPÇÂO",
+] as const
+
+export type Setor = typeof SETORES[number]


### PR DESCRIPTION
## Summary
- list available setores
- add dropdown with setor options to purchase authorization form

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm -r test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685acebeb68c832483e4c04a628b1cb0