### PR TITLE
Move clear button next to filter apply

### DIFF
--- a/frontend/src/components/FiltroDataIntervalo.tsx
+++ b/frontend/src/components/FiltroDataIntervalo.tsx
@@ -101,9 +101,17 @@ const FiltroDataIntervalo: React.FC<FiltroDataIntervaloProps> = ({
                     />
                 </Grid>
 
-                <Grid item xs={12} md={4}>
-                    <Button variant="contained" color="primary" onClick={handleFiltrar} disabled={!!error} fullWidth>
+                <Grid item xs={12} md={4} sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                    <Button
+                        variant="contained"
+                        color="primary"
+                        onClick={handleFiltrar}
+                        disabled={!!error}
+                    >
                         Aplicar Filtro
+                    </Button>
+                    <Button variant="outlined" color="secondary" onClick={handleLimpar}>
+                        Limpar
                     </Button>
                 </Grid>
 
@@ -124,9 +132,6 @@ const FiltroDataIntervalo: React.FC<FiltroDataIntervaloProps> = ({
                             </Button>
                         </>
                     )}
-                    <Button size="small" color="secondary" onClick={handleLimpar} sx={{ mt: 1 }}>
-                        Limpar
-                    </Button>
                 </Grid>
             </Grid>
         </LocalizationProvider>


### PR DESCRIPTION
## Summary
- update data interval filter layout so "Limpar" button sits beside "Aplicar Filtro"

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*
- `npm run lint --silent` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ae5e6e00483248f13bd502a021c1c