### PR TITLE
Fix filter alignment

### DIFF
--- a/frontend/src/components/FiltroDataIntervalo.tsx
+++ b/frontend/src/components/FiltroDataIntervalo.tsx
@@ -108,7 +108,7 @@ const FiltroDataIntervalo: React.FC<FiltroDataIntervaloProps> = ({
                         onClick={handleFiltrar}
                         disabled={!!error}
                     >
-                        Aplicar Filtro
+                        Filtrar
                     </Button>
                     <Button variant="outlined" color="secondary" onClick={handleLimpar}>
                         Limpar

--- a/frontend/src/pages/AutorizacaoCompra.tsx
+++ b/frontend/src/pages/AutorizacaoCompra.tsx
@@ -418,7 +418,7 @@ const AutorizacaoCompraPage: React.FC = () => {
                                     }}
                                 />
                             </Box>
-                            <Box sx={{ flex: "1 1 260px", minWidth: 260 }}>
+                            <Box sx={{ flex: "1 1 220px", minWidth: 220 }}>
                                 <FiltroDataIntervalo
                                     showQuickFilters={false}
                                     onFiltrar={(inicio, fim) => {


### PR DESCRIPTION
## Summary
- shorten text on quick date filter button to `Filtrar`
- reduce width of date filter box on authorization page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aeb399b0883249ff46c2461dfa028