### PR TITLE
Fix CORS configuration

### DIFF
--- a/backend/src/config/cors.ts
+++ b/backend/src/config/cors.ts
@@ -1,8 +1,13 @@
 import cors from "cors"
 
-// Configuração do CORS para permitir a comunicação entre frontend e backend
+// Configuração do CORS para permitir a comunicação entre frontend e backend.
+// A variável FRONTEND_URL pode conter uma lista de origens separadas por vírgula.
+const allowedOrigins = (process.env.FRONTEND_URL || "http://localhost:8000")
+    .split(",")
+    .map((origin) => origin.trim())
+
 const corsOptions = {
-    origin: process.env.FRONTEND_URL || "http://localhost:8000",
+    origin: allowedOrigins,
     methods: ["GET", "POST", "PUT", "DELETE"],
     allowedHeaders: ["Content-Type", "Authorization"],
 }


### PR DESCRIPTION
## Summary
- relax backend CORS settings to allow multiple origins via `FRONTEND_URL`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685be2a8b3ac8324b64299796296c1fc