### PR TITLE
Fix CORS origin configuration

### DIFF
--- a/backend/src/config/cors.ts
+++ b/backend/src/config/cors.ts
@@ -1,10 +1,27 @@
 import cors from "cors"
 
-// Configuração do CORS para permitir a comunicação entre frontend e backend
-const corsOptions = {
-    origin: process.env.FRONTEND_URL || "http://localhost:8000",
-    methods: ["GET", "POST", "PUT", "DELETE"],
-    allowedHeaders: ["Content-Type", "Authorization"],
-}
+/**
+ * Configuração do CORS para permitir a comunicação entre frontend e backend.
+ *
+ * Se a variável de ambiente `FRONTEND_URL` estiver definida, ela é utilizada
+ * como origem permitida. Caso contrário, todas as origens são aceitas para
+ * evitar problemas em ambientes de desenvolvimento onde o endereço pode variar.
+ */
+
+const allowedOrigins = process.env.FRONTEND_URL
+  ? process.env.FRONTEND_URL.split(',').map(origin => origin.trim()).filter(Boolean)
+  : []
+
+const corsOptions = allowedOrigins.length > 0
+  ? {
+      origin: allowedOrigins,
+      methods: ["GET", "POST", "PUT", "DELETE"],
+      allowedHeaders: ["Content-Type", "Authorization"],
+    }
+  : {
+      origin: "*",
+      methods: ["GET", "POST", "PUT", "DELETE"],
+      allowedHeaders: ["Content-Type", "Authorization"],
+    }
 
 export const corsMiddleware = cors(corsOptions)


### PR DESCRIPTION
## Summary
- update CORS middleware so that it reads `FRONTEND_URL` from environment
- allow any origin if the variable is not set

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685be49c9110832489dbd18faa2bc636