### PR TITLE
Fix update route

### DIFF
--- a/backend/src/routes/autorizacaoCompraRoutes.ts
+++ b/backend/src/routes/autorizacaoCompraRoutes.ts
@@ -27,6 +27,12 @@ router.put(
     verificarPermissao("autorizacao-compra", "editar"),
     autorizacaoCompraController.atualizarAutorizacao,
 )
+router.patch(
+    "/:id",
+    verificarAutenticacao,
+    verificarPermissao("autorizacao-compra", "editar"),
+    autorizacaoCompraController.atualizarAutorizacao,
+)
 router.put(
     "/:id/autorizar-controladoria",
     verificarAutenticacao,

--- a/frontend/src/services/autorizacaoCompraService.ts
+++ b/frontend/src/services/autorizacaoCompraService.ts
@@ -46,7 +46,7 @@ export const atualizarAutorizacao = async (
     id: number,
     autorizacao: Partial<AutorizacaoCompra>,
 ): Promise<AutorizacaoCompra> => {
-    const response = await api.put(`/autorizacao-compra/${id}`, autorizacao)
+    const response = await api.patch(`/autorizacao-compra/${id}`, autorizacao)
     return response.data
 }
 


### PR DESCRIPTION
## Summary
- support PATCH method for atualizarAutorizacao route in backend
- switch frontend service to use PATCH when updating a record

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bfd64bef88324a3889a25744fb2ff