### PR TITLE
Load vendor data from API in commissions page

### DIFF
--- a/frontend/src/services/comissaoVendedorService.ts
+++ b/frontend/src/services/comissaoVendedorService.ts
@@ -1,0 +1,42 @@
+import api from "./api"
+import type { Vendedor, Loja, ComissaoVendedor } from "../types"
+
+export const getVendedores = async (): Promise<Vendedor[]> => {
+  const response = await api.get("/comissoes-vendedores/vendedores")
+  return response.data
+}
+
+export const getLojas = async (): Promise<Loja[]> => {
+  const response = await api.get("/comissoes-vendedores/lojas")
+  return response.data
+}
+
+export const getComissoesVendedores = async (): Promise<ComissaoVendedor[]> => {
+  const response = await api.get("/comissoes-vendedores")
+  return response.data
+}
+
+export const criarComissaoVendedor = async (
+  comissao: Omit<ComissaoVendedor, "id">
+): Promise<ComissaoVendedor> => {
+  const response = await api.post("/comissoes-vendedores", comissao)
+  return response.data
+}
+
+export const atualizarComissaoVendedor = async (
+  id: number,
+  comissao: Omit<ComissaoVendedor, "id">
+): Promise<ComissaoVendedor> => {
+  const response = await api.put(`/comissoes-vendedores/${id}`, comissao)
+  return response.data
+}
+
+export const excluirComissaoVendedor = async (id: number): Promise<void> => {
+  await api.delete(`/comissoes-vendedores/${id}`)
+}
+
+export const getComissaoVendedor = async (id: number): Promise<ComissaoVendedor> => {
+  const response = await api.get(`/comissoes-vendedores/${id}`)
+  return response.data
+}
+

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -89,6 +89,28 @@ export interface VendedorMetaCompleta extends VendedorMeta {
   codloja?: string
 }
 
+// Tipos para o módulo de Comissões de Vendedores
+export interface Loja {
+  codloja: string
+  loja: string
+}
+
+export interface ComissaoVendedor {
+  id?: number
+  codvendedor: string
+  vendedor?: string
+  nome_completo?: string
+  codloja: string
+  loja?: string
+  percentual_base: number
+  percentual_extra: number
+  meta_mensal: number
+  ativo: boolean
+  data_inicio: string
+  data_fim?: string
+  observacoes?: string
+}
+
 // Tipos para o módulo de Autorização de Compra
 export interface AutorizacaoCompra {
   id?: number


### PR DESCRIPTION
## Summary
- define TS interfaces for vendor commissions
- add API client for vendor commissions
- fetch real commission data in `ComissoesVendedores`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688271b52f408324a1c40b278bfcbdb3