### PR TITLE
Add sales totals to commission page

### DIFF
--- a/backend/src/models/VendedorMeta.ts
+++ b/backend/src/models/VendedorMeta.ts
@@ -23,4 +23,7 @@ export interface VendedorMetaCompleta extends VendedorMeta {
     vendedor?: string
     nome_completo?: string
     codloja?: string
+    venda_bruta?: number
+    devolucao?: number
+    valor_liquido?: number
 }

--- a/backend/src/services/vendedorMetaService.ts
+++ b/backend/src/services/vendedorMetaService.ts
@@ -119,9 +119,21 @@ export const getMetasPorCompetencia = async (competencia: string): Promise<Vende
         m.incluc100,
         v.vendedor,
         v.nome_completo,
-        v.codloja
+        v.codloja,
+        COALESCE(vd.venda_bruta, 0) AS venda_bruta,
+        COALESCE(vd.devolucao, 0) AS devolucao,
+        COALESCE(vd.valor_liquido, 0) AS valor_liquido
       FROM pwb_vendedor_metas m
       LEFT JOIN vs_pwb_dvendedores v ON m.codvendedor = v.codvendedor
+      LEFT JOIN (
+        SELECT codvendedor,
+               date_trunc('month', mes) AS mes,
+               SUM(venda_bruta) AS venda_bruta,
+               SUM(devolucao) AS devolucao,
+               SUM(valor_liquido) AS valor_liquido
+        FROM vs_pwb_comissao_vendedores
+        GROUP BY codvendedor, date_trunc('month', mes)
+      ) vd ON vd.codvendedor = m.codvendedor AND TO_CHAR(vd.mes, 'YYYY-MM') = $1
       WHERE TO_CHAR(m.competencia, 'YYYY-MM') = $1
       ORDER BY v.vendedor
     `
@@ -166,9 +178,21 @@ export const getMetaVendedor = async (
         m.incluc100,
         v.vendedor,
         v.nome_completo,
-        v.codloja
+        v.codloja,
+        COALESCE(vd.venda_bruta, 0) AS venda_bruta,
+        COALESCE(vd.devolucao, 0) AS devolucao,
+        COALESCE(vd.valor_liquido, 0) AS valor_liquido
       FROM pwb_vendedor_metas m
       LEFT JOIN vs_pwb_dvendedores v ON m.codvendedor = v.codvendedor
+      LEFT JOIN (
+        SELECT codvendedor,
+               date_trunc('month', mes) AS mes,
+               SUM(venda_bruta) AS venda_bruta,
+               SUM(devolucao) AS devolucao,
+               SUM(valor_liquido) AS valor_liquido
+        FROM vs_pwb_comissao_vendedores
+        GROUP BY codvendedor, date_trunc('month', mes)
+      ) vd ON vd.codvendedor = m.codvendedor AND TO_CHAR(vd.mes, 'YYYY-MM') = $2
       WHERE m.codvendedor = $1 AND TO_CHAR(m.competencia, 'YYYY-MM') = $2
     `
 

--- a/frontend/src/pages/ComissaoVendedores.tsx
+++ b/frontend/src/pages/ComissaoVendedores.tsx
@@ -101,6 +101,9 @@ const ComissaoVendedores: React.FC = () => {
                                 <TableCell>Base Salarial</TableCell>
                                 <TableCell>Meta Faturamento</TableCell>
                                 <TableCell>Meta Lucro</TableCell>
+                                <TableCell>Venda Bruta</TableCell>
+                                <TableCell>Devolução</TableCell>
+                                <TableCell>Venda Líquida</TableCell>
                                 <TableCell>Fat. Mínimo</TableCell>
                                 <TableCell>IncFat 90%</TableCell>
                                 <TableCell>IncFat 100%</TableCell>
@@ -117,6 +120,9 @@ const ComissaoVendedores: React.FC = () => {
                                     <TableCell>{formatarValor(Number(meta.base_salarial) || 0)}</TableCell>
                                     <TableCell>{formatarValor(Number(meta.meta_faturamento) || 0)}</TableCell>
                                     <TableCell>{formatarPercentual(Number(meta.meta_lucra) || 0)}</TableCell>
+                                    <TableCell>{formatarValor(Number(meta.venda_bruta) || 0)}</TableCell>
+                                    <TableCell>{formatarValor(Number(meta.devolucao) || 0)}</TableCell>
+                                    <TableCell>{formatarValor(Number(meta.valor_liquido) || 0)}</TableCell>
                                     <TableCell>{formatarValor(Number(meta.faturamento_minimo) || 0)}</TableCell>
                                     <TableCell>{formatarValor(Number(meta.incfat90) || 0)}</TableCell>
                                     <TableCell>{formatarValor(Number(meta.incfat100) || 0)}</TableCell>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -87,6 +87,9 @@ export interface VendedorMetaCompleta extends VendedorMeta {
   vendedor?: string
   nome_completo?: string
   codloja?: string
+  venda_bruta?: number
+  devolucao?: number
+  valor_liquido?: number
 }
 
 // Tipos para o módulo de Comissões de Vendedores


### PR DESCRIPTION
## Summary
- add sales metrics to vendor meta models
- expand queries in `vendedorMetaService` to pull sales totals from new DB view
- show venda bruta, devolucao and valor liquido on commission page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688910c7faf88324a30c700eae813511