### PR TITLE
Adicionar segredo JWT de desenvolvimento quando JWT_SECRET não estiver definido

### DIFF
--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -5,10 +5,16 @@ import crypto from "crypto"
 
 const getJwtSecret = (): string => {
     const secret = process.env.JWT_SECRET
-    if (!secret) {
-        throw new Error("JWT_SECRET não definido. Defina a variável de ambiente JWT_SECRET antes de iniciar o servidor.")
+    if (secret) {
+        return secret
     }
-    return secret
+
+    if (process.env.NODE_ENV !== "production") {
+        console.warn("JWT_SECRET não definido. Usando segredo padrão de desenvolvimento (inseguro).")
+        return "dev-jwt-secret-insecure-change-me"
+    }
+
+    throw new Error("JWT_SECRET não definido. Defina a variável de ambiente JWT_SECRET antes de iniciar o servidor.")
 }
 
 // Mantido para compatibilidade com senhas legadas no banco (MD5).


### PR DESCRIPTION
### Motivation
- Corrigir erro de autenticação que impedia login em ambientes onde a variável de ambiente `JWT_SECRET` não está definida; manter comportamento seguro em produção.

### Description
- Atualiza `backend/src/services/authService.ts` para retornar imediatamente `process.env.JWT_SECRET` quando presente.
- Adiciona um segredo de fallback de desenvolvimento (`"dev-jwt-secret-insecure-change-me"`) e um `console.warn` quando `NODE_ENV !== "production"` para permitir execução local sem `JWT_SECRET`.
- Mantém a exceção existente para falhar com erro explícito quando `JWT_SECRET` estiver ausente em `production`.

### Testing
- Executado `npm --prefix backend run build` com sucesso, compilando o TypeScript sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8f6bd05a8832481e4c3c89f2db9c1)