### PR TITLE
feat: módulo Compradores (cadastro, vínculo por grupo e metas)

### DIFF
--- a/backend/sql/compradores.sql
+++ b/backend/sql/compradores.sql
@@ -1,0 +1,47 @@
+CREATE TABLE IF NOT EXISTS scc_compradores (
+  id BIGSERIAL PRIMARY KEY,
+  nome VARCHAR(150) NOT NULL,
+  ativo BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS scc_comprador_grupo (
+  id BIGSERIAL PRIMARY KEY,
+  codgrp CHAR(2) NOT NULL,
+  comprador_id BIGINT NOT NULL REFERENCES scc_compradores(id),
+  dt_inicio DATE NOT NULL DEFAULT CURRENT_DATE,
+  dt_fim DATE NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_scc_comprador_grupo_ativo
+ON scc_comprador_grupo(codgrp)
+WHERE dt_fim IS NULL;
+
+CREATE TABLE IF NOT EXISTS scc_metas_compradores (
+  id BIGSERIAL PRIMARY KEY,
+  comprador_id BIGINT NOT NULL REFERENCES scc_compradores(id),
+  codgrp CHAR(2) NOT NULL,
+  ano INT NOT NULL,
+  mes INT NOT NULL,
+  meta_vendas NUMERIC(15,2) DEFAULT 0,
+  meta_lb NUMERIC(15,2) DEFAULT 0,
+  meta_evolucao NUMERIC(8,2) DEFAULT 0,
+  meta_nivel_servico NUMERIC(8,2) DEFAULT 0,
+  meta_dias_estoque NUMERIC(8,2) DEFAULT 0,
+  meta_produtos_fora NUMERIC(8,2) DEFAULT 0,
+  UNIQUE (comprador_id, codgrp, ano, mes)
+);
+
+CREATE OR REPLACE VIEW vs_scc_dgrupos AS
+SELECT
+    a.c_grp AS codgrp,
+    a.c_grp::text || a.c_subgrp::text AS codgrupo,
+    a.c_nomgrp AS grupo,
+    a.c_nomsubgr AS subgrupo,
+    c.nome AS comprador
+FROM a_classi a
+LEFT JOIN scc_comprador_grupo cg
+    ON cg.codgrp = a.c_grp
+    AND cg.dt_fim IS NULL
+LEFT JOIN scc_compradores c
+    ON c.id = cg.comprador_id;

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -9,6 +9,7 @@ import autorizacaoCompraRoutes from "./routes/autorizacaoCompraRoutes"
 import controleAcessoRoutes from "./routes/controleAcessoRoutes"
 import dreRoutes from "./routes/dreRoutes"
 import helpDeskRoutes from "./routes/helpDeskRoutes"
+import compradoresRoutes from "./routes/compradoresRoutes"
 import { corsMiddleware } from "./config/cors"
 
 // Carrega as variáveis de ambiente antes de qualquer outra operação
@@ -31,6 +32,7 @@ app.use("/api/autorizacao-compra", autorizacaoCompraRoutes)
 app.use("/api/controle-acesso", controleAcessoRoutes)
 app.use("/api/dre", dreRoutes)
 app.use("/api/help-desk", helpDeskRoutes)
+app.use("/api", compradoresRoutes)
 
 // Rota de teste para verificar se o servidor está funcionando
 app.get("/", (req, res) => {

--- a/backend/src/controllers/compradoresController.ts
+++ b/backend/src/controllers/compradoresController.ts
@@ -1,0 +1,22 @@
+import type { Request, Response } from "express"
+import * as service from "../services/compradoresService"
+
+export const getCompradores = async (_: Request, res: Response) => res.json(await service.getCompradores())
+export const criarComprador = async (req: Request, res: Response) => res.status(201).json(await service.criarComprador(req.body.nome, req.body.ativo))
+export const atualizarComprador = async (req: Request, res: Response) => res.json(await service.atualizarComprador(Number(req.params.id), req.body.nome, req.body.ativo))
+export const excluirComprador = async (req: Request, res: Response) => res.json({ sucesso: await service.excluirComprador(Number(req.params.id)) })
+
+export const getCompradorGrupo = async (_: Request, res: Response) => res.json(await service.getCompradorGrupo())
+export const criarCompradorGrupo = async (req: Request, res: Response) => res.status(201).json(await service.criarCompradorGrupo(req.body.codgrp, req.body.comprador_id, req.body.dt_inicio))
+export const atualizarCompradorGrupo = async (req: Request, res: Response) => res.json(await service.atualizarCompradorGrupo(Number(req.params.id), req.body.codgrp, req.body.comprador_id, req.body.dt_inicio, req.body.dt_fim))
+export const excluirCompradorGrupo = async (req: Request, res: Response) => res.json({ sucesso: await service.excluirCompradorGrupo(Number(req.params.id)) })
+
+export const getMetasCompradores = async (req: Request, res: Response) => {
+  const ano = req.query.ano ? Number(req.query.ano) : undefined
+  const mes = req.query.mes ? Number(req.query.mes) : undefined
+  const comprador_id = req.query.comprador_id ? Number(req.query.comprador_id) : undefined
+  res.json(await service.getMetasCompradores({ ano, mes, comprador_id }))
+}
+export const criarMetaComprador = async (req: Request, res: Response) => res.status(201).json(await service.criarMetaComprador(req.body))
+export const atualizarMetaComprador = async (req: Request, res: Response) => res.json(await service.atualizarMetaComprador(Number(req.params.id), req.body))
+export const excluirMetaComprador = async (req: Request, res: Response) => res.json({ sucesso: await service.excluirMetaComprador(Number(req.params.id)) })

--- a/backend/src/routes/compradoresRoutes.ts
+++ b/backend/src/routes/compradoresRoutes.ts
@@ -1,0 +1,23 @@
+import { Router } from "express"
+import * as controller from "../controllers/compradoresController"
+import { verificarAutenticacao } from "../middlewares/authMiddleware"
+
+const router = Router()
+router.use(verificarAutenticacao)
+
+router.get("/compradores", controller.getCompradores)
+router.post("/compradores", controller.criarComprador)
+router.put("/compradores/:id", controller.atualizarComprador)
+router.delete("/compradores/:id", controller.excluirComprador)
+
+router.get("/comprador-grupo", controller.getCompradorGrupo)
+router.post("/comprador-grupo", controller.criarCompradorGrupo)
+router.put("/comprador-grupo/:id", controller.atualizarCompradorGrupo)
+router.delete("/comprador-grupo/:id", controller.excluirCompradorGrupo)
+
+router.get("/metas-compradores", controller.getMetasCompradores)
+router.post("/metas-compradores", controller.criarMetaComprador)
+router.put("/metas-compradores/:id", controller.atualizarMetaComprador)
+router.delete("/metas-compradores/:id", controller.excluirMetaComprador)
+
+export default router

--- a/backend/src/services/compradoresService.ts
+++ b/backend/src/services/compradoresService.ts
@@ -1,0 +1,130 @@
+import pool from "../config/database"
+
+export const getCompradores = async () => {
+  const result = await pool.query(`
+    SELECT id, nome, ativo, created_at
+    FROM scc_compradores
+    ORDER BY nome
+  `)
+  return result.rows
+}
+
+export const criarComprador = async (nome: string, ativo = true) => {
+  const result = await pool.query(
+    `INSERT INTO scc_compradores (nome, ativo) VALUES ($1, $2) RETURNING id, nome, ativo, created_at`,
+    [nome, ativo],
+  )
+  return result.rows[0]
+}
+
+export const atualizarComprador = async (id: number, nome: string, ativo: boolean) => {
+  const result = await pool.query(
+    `UPDATE scc_compradores SET nome = $1, ativo = $2 WHERE id = $3 RETURNING id, nome, ativo, created_at`,
+    [nome, ativo, id],
+  )
+  return result.rows[0] || null
+}
+
+export const excluirComprador = async (id: number) => {
+  const result = await pool.query(`DELETE FROM scc_compradores WHERE id = $1 RETURNING id`, [id])
+  return result.rows.length > 0
+}
+
+export const getCompradorGrupo = async () => {
+  const result = await pool.query(`
+    SELECT cg.id, cg.codgrp, cg.comprador_id, c.nome as comprador_nome, cg.dt_inicio, cg.dt_fim
+    FROM scc_comprador_grupo cg
+    INNER JOIN scc_compradores c ON c.id = cg.comprador_id
+    ORDER BY cg.codgrp, cg.dt_inicio DESC
+  `)
+  return result.rows
+}
+
+export const criarCompradorGrupo = async (codgrp: string, compradorId: number, dtInicio?: string) => {
+  const client = await pool.connect()
+  try {
+    await client.query("BEGIN")
+    await client.query(
+      `UPDATE scc_comprador_grupo SET dt_fim = CURRENT_DATE WHERE codgrp = $1 AND dt_fim IS NULL`,
+      [codgrp],
+    )
+    const result = await client.query(
+      `INSERT INTO scc_comprador_grupo (codgrp, comprador_id, dt_inicio) VALUES ($1, $2, COALESCE($3::date, CURRENT_DATE))
+       RETURNING id, codgrp, comprador_id, dt_inicio, dt_fim`,
+      [codgrp, compradorId, dtInicio || null],
+    )
+    await client.query("COMMIT")
+    return result.rows[0]
+  } catch (error) {
+    await client.query("ROLLBACK")
+    throw error
+  } finally {
+    client.release()
+  }
+}
+
+export const atualizarCompradorGrupo = async (id: number, codgrp: string, compradorId: number, dtInicio: string, dtFim?: string | null) => {
+  const result = await pool.query(
+    `UPDATE scc_comprador_grupo
+     SET codgrp = $1, comprador_id = $2, dt_inicio = $3, dt_fim = $4
+     WHERE id = $5
+     RETURNING id, codgrp, comprador_id, dt_inicio, dt_fim`,
+    [codgrp, compradorId, dtInicio, dtFim || null, id],
+  )
+  return result.rows[0] || null
+}
+
+export const excluirCompradorGrupo = async (id: number) => {
+  const result = await pool.query(`DELETE FROM scc_comprador_grupo WHERE id = $1 RETURNING id`, [id])
+  return result.rows.length > 0
+}
+
+export const getMetasCompradores = async (filtros: { ano?: number; mes?: number; comprador_id?: number }) => {
+  const values: Array<number> = []
+  const where: string[] = []
+  if (filtros.ano) { values.push(filtros.ano); where.push(`m.ano = $${values.length}`) }
+  if (filtros.mes) { values.push(filtros.mes); where.push(`m.mes = $${values.length}`) }
+  if (filtros.comprador_id) { values.push(filtros.comprador_id); where.push(`m.comprador_id = $${values.length}`) }
+
+  const query = `
+    SELECT m.*, c.nome AS comprador_nome
+    FROM scc_metas_compradores m
+    INNER JOIN scc_compradores c ON c.id = m.comprador_id
+    ${where.length ? `WHERE ${where.join(" AND ")}` : ""}
+    ORDER BY m.ano DESC, m.mes DESC, m.codgrp
+  `
+  const result = await pool.query(query, values)
+  return result.rows
+}
+
+export const criarMetaComprador = async (payload: any) => {
+  const result = await pool.query(`
+    INSERT INTO scc_metas_compradores (
+      comprador_id, codgrp, ano, mes, meta_vendas, meta_lb, meta_evolucao, meta_nivel_servico, meta_dias_estoque, meta_produtos_fora
+    ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+    RETURNING *
+  `, [
+    payload.comprador_id, payload.codgrp, payload.ano, payload.mes, payload.meta_vendas, payload.meta_lb,
+    payload.meta_evolucao, payload.meta_nivel_servico, payload.meta_dias_estoque, payload.meta_produtos_fora,
+  ])
+  return result.rows[0]
+}
+
+export const atualizarMetaComprador = async (id: number, payload: any) => {
+  const result = await pool.query(`
+    UPDATE scc_metas_compradores SET
+      comprador_id=$1, codgrp=$2, ano=$3, mes=$4, meta_vendas=$5, meta_lb=$6, meta_evolucao=$7,
+      meta_nivel_servico=$8, meta_dias_estoque=$9, meta_produtos_fora=$10
+    WHERE id=$11
+    RETURNING *
+  `, [
+    payload.comprador_id, payload.codgrp, payload.ano, payload.mes, payload.meta_vendas, payload.meta_lb,
+    payload.meta_evolucao, payload.meta_nivel_servico, payload.meta_dias_estoque, payload.meta_produtos_fora, id,
+  ])
+  return result.rows[0] || null
+}
+
+export const excluirMetaComprador = async (id: number) => {
+  const result = await pool.query(`DELETE FROM scc_metas_compradores WHERE id = $1 RETURNING id`, [id])
+  return result.rows.length > 0
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,9 @@ import HelpDeskChamados from "./pages/HelpDeskChamados"
 import HelpDeskAtivos from "./pages/HelpDeskAtivos"
 import { AuthProvider } from "./contexts/AuthContext"
 import { ThemeProvider } from "./contexts/ThemeContext"
+import Compradores from "./pages/Compradores"
+import CompradoresGrupos from "./pages/CompradoresGrupos"
+import CompradoresMetas from "./pages/CompradoresMetas"
 
 function App() {
   console.log("App renderizando")
@@ -274,6 +277,10 @@ function App() {
                 </ProtectedRoute>
               }
             />
+
+            <Route path="/compradores" element={<ProtectedRoute><Layout><Compradores /></Layout></ProtectedRoute>} />
+            <Route path="/compradores/grupos" element={<ProtectedRoute><Layout><CompradoresGrupos /></Layout></ProtectedRoute>} />
+            <Route path="/compradores/metas" element={<ProtectedRoute><Layout><CompradoresMetas /></Layout></ProtectedRoute>} />
           </Routes>
         </AuthProvider>
       </Router>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -45,6 +45,7 @@ import {
     VpnKey as PermissoesIcon,
     TableChart as DreIcon,
     SupportAgent as HelpDeskIcon,
+    ShoppingBasket as CompradoresIcon,
     ConfirmationNumber as ChamadosIcon,
     Computer as AtivosIcon,
 } from "@mui/icons-material"
@@ -140,6 +141,15 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
                 { text: "Faixas de Comissão", icon: <BarChart />, path: "/comissao/faixas" },
                 { text: "Metas Vendedores", icon: <PersonIcon />, path: "/comissao/metas" },
                 { text: "Comissão Vendedores", icon: <PersonIcon />, path: "/comissao/vendedores" },
+            ],
+        },
+        {
+            text: "Compradores",
+            icon: <CompradoresIcon />,
+            subItems: [
+                { text: "Compradores", icon: <PersonIcon />, path: "/compradores" },
+                { text: "Grupos", icon: <BarChart />, path: "/compradores/grupos" },
+                { text: "Metas", icon: <AttachMoney />, path: "/compradores/metas" },
             ],
         },
         {

--- a/frontend/src/pages/Compradores.tsx
+++ b/frontend/src/pages/Compradores.tsx
@@ -1,0 +1,24 @@
+import { Box, Button, Switch, TextField, Typography } from "@mui/material"
+import { useEffect, useState } from "react"
+import { criarComprador, excluirComprador, listarCompradores } from "../services/compradoresService"
+
+export default function Compradores() {
+  const [nome, setNome] = useState("")
+  const [ativo, setAtivo] = useState(true)
+  const [itens, setItens] = useState<any[]>([])
+  const carregar = async () => setItens(await listarCompradores())
+  useEffect(() => { carregar() }, [])
+
+  return <Box>
+    <Typography variant="h5">Compradores</Typography>
+    <Box sx={{ display: "flex", gap: 2, my: 2 }}>
+      <TextField label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} />
+      <Box sx={{ display: "flex", alignItems: "center" }}>Ativo <Switch checked={ativo} onChange={(_, v) => setAtivo(v)} /></Box>
+      <Button variant="contained" onClick={async () => { await criarComprador({ nome, ativo }); setNome(""); carregar() }}>Salvar</Button>
+    </Box>
+    {itens.map((c) => <Box key={c.id} sx={{ display: "flex", gap: 2, py: 1 }}>
+      <Typography>{c.nome}</Typography><Typography>{c.ativo ? "Ativo" : "Inativo"}</Typography>
+      <Button color="error" onClick={async () => { await excluirComprador(c.id); carregar() }}>Excluir</Button>
+    </Box>)}
+  </Box>
+}

--- a/frontend/src/pages/CompradoresGrupos.tsx
+++ b/frontend/src/pages/CompradoresGrupos.tsx
@@ -1,0 +1,27 @@
+import { Box, Button, MenuItem, TextField, Typography } from "@mui/material"
+import { useEffect, useState } from "react"
+import { criarCompradorGrupo, listarCompradorGrupo, listarCompradores } from "../services/compradoresService"
+
+export default function CompradoresGrupos() {
+  const [compradores, setCompradores] = useState<any[]>([])
+  const [vinculos, setVinculos] = useState<any[]>([])
+  const [codgrp, setCodgrp] = useState("")
+  const [compradorId, setCompradorId] = useState("")
+  const carregar = async () => {
+    setCompradores(await listarCompradores())
+    setVinculos(await listarCompradorGrupo())
+  }
+  useEffect(() => { carregar() }, [])
+
+  return <Box>
+    <Typography variant="h5">Grupos x Compradores</Typography>
+    <Box sx={{ display: "flex", gap: 2, my: 2 }}>
+      <TextField label="Grupo (c_grp)" value={codgrp} onChange={(e) => setCodgrp(e.target.value)} inputProps={{ maxLength: 2 }} />
+      <TextField select label="Comprador" value={compradorId} onChange={(e) => setCompradorId(e.target.value)} sx={{ minWidth: 260 }}>
+        {compradores.map((c) => <MenuItem key={c.id} value={c.id}>{c.nome}</MenuItem>)}
+      </TextField>
+      <Button variant="contained" onClick={async () => { await criarCompradorGrupo({ codgrp, comprador_id: Number(compradorId) }); carregar() }}>Vincular</Button>
+    </Box>
+    {vinculos.map((v) => <Typography key={v.id}>{v.codgrp} - {v.comprador_nome} ({v.dt_fim ? "Histórico" : "Atual"})</Typography>)}
+  </Box>
+}

--- a/frontend/src/pages/CompradoresMetas.tsx
+++ b/frontend/src/pages/CompradoresMetas.tsx
@@ -1,0 +1,38 @@
+import { Box, Button, MenuItem, TextField, Typography } from "@mui/material"
+import { useEffect, useState } from "react"
+import { listarCompradores, listarMetasCompradores, salvarMetaComprador } from "../services/compradoresService"
+
+export default function CompradoresMetas() {
+  const [ano, setAno] = useState(new Date().getFullYear())
+  const [mes, setMes] = useState(new Date().getMonth() + 1)
+  const [compradorId, setCompradorId] = useState("")
+  const [compradores, setCompradores] = useState<any[]>([])
+  const [metas, setMetas] = useState<any[]>([])
+  const carregar = async () => {
+    setMetas(await listarMetasCompradores({ ano, mes, comprador_id: compradorId || undefined }))
+    setCompradores(await listarCompradores())
+  }
+  useEffect(() => { carregar() }, [])
+
+  return <Box>
+    <Typography variant="h5">Metas de Compradores</Typography>
+    <Box sx={{ display: "flex", gap: 2, my: 2 }}>
+      <TextField label="Ano" type="number" value={ano} onChange={(e) => setAno(Number(e.target.value))} />
+      <TextField label="Mês" type="number" value={mes} onChange={(e) => setMes(Number(e.target.value))} />
+      <TextField select label="Comprador" value={compradorId} onChange={(e) => setCompradorId(e.target.value)} sx={{ minWidth: 250 }}>
+        <MenuItem value="">Todos</MenuItem>
+        {compradores.map((c) => <MenuItem key={c.id} value={c.id}>{c.nome}</MenuItem>)}
+      </TextField>
+      <Button variant="outlined" onClick={carregar}>Filtrar</Button>
+    </Box>
+    {metas.map((m) => <Box key={m.id} sx={{ display: "flex", gap: 1, my: 1 }}>
+      <Typography sx={{ minWidth: 90 }}>{m.codgrp}</Typography>
+      <TextField size="small" label="Vendas" defaultValue={m.meta_vendas} onBlur={async (e) => await salvarMetaComprador({ ...m, meta_vendas: Number(e.target.value) })} />
+      <TextField size="small" label="LB" defaultValue={m.meta_lb} onBlur={async (e) => await salvarMetaComprador({ ...m, meta_lb: Number(e.target.value) })} />
+      <TextField size="small" label="Evolução" defaultValue={m.meta_evolucao} onBlur={async (e) => await salvarMetaComprador({ ...m, meta_evolucao: Number(e.target.value) })} />
+      <TextField size="small" label="Nível Serviço" defaultValue={m.meta_nivel_servico} onBlur={async (e) => await salvarMetaComprador({ ...m, meta_nivel_servico: Number(e.target.value) })} />
+      <TextField size="small" label="Dias Estoque" defaultValue={m.meta_dias_estoque} onBlur={async (e) => await salvarMetaComprador({ ...m, meta_dias_estoque: Number(e.target.value) })} />
+      <TextField size="small" label="Prod. Fora" defaultValue={m.meta_produtos_fora} onBlur={async (e) => await salvarMetaComprador({ ...m, meta_produtos_fora: Number(e.target.value) })} />
+    </Box>)}
+  </Box>
+}

--- a/frontend/src/services/compradoresService.ts
+++ b/frontend/src/services/compradoresService.ts
@@ -1,0 +1,14 @@
+import api from "./api"
+
+export const listarCompradores = async () => (await api.get("/compradores")).data
+export const criarComprador = async (payload: any) => (await api.post("/compradores", payload)).data
+export const atualizarComprador = async (id: number, payload: any) => (await api.put(`/compradores/${id}`, payload)).data
+export const excluirComprador = async (id: number) => (await api.delete(`/compradores/${id}`)).data
+
+export const listarCompradorGrupo = async () => (await api.get("/comprador-grupo")).data
+export const criarCompradorGrupo = async (payload: any) => (await api.post("/comprador-grupo", payload)).data
+
+export const listarMetasCompradores = async (params: any) => (await api.get("/metas-compradores", { params })).data
+export const salvarMetaComprador = async (meta: any) => meta.id
+  ? (await api.put(`/metas-compradores/${meta.id}`, meta)).data
+  : (await api.post("/metas-compradores", meta)).data


### PR DESCRIPTION
### Motivation

- Adicionar um módulo para gerenciar compradors, vínculos por `c_grp` (CHAR(2)) e metas mensais por grupo para análises e dashboards futuros. 
- Garantir histórico de vínculos com `dt_inicio`/`dt_fim` permitindo trocar compradores sem perder o histórico. 
- Expor dados relacionando `c_grp` à tabela de classificação (`a_classi`) para uso em views/Power BI.

### Description

- Adiciona scripts SQL em `backend/sql/compradores.sql` criando as tabelas `scc_compradores`, `scc_comprador_grupo`, `scc_metas_compradores`, o índice único `ux_scc_comprador_grupo_ativo` (1 vínculo ativo por `codgrp`) e a view `vs_scc_dgrupos` (relacionamento por `c_grp`).
- Implementa backend Express/Postgres com service/controller/routes para CRUD de `/compradores`, `/comprador-grupo` e `/metas-compradores` e monta as rotas na API (`app.use("/api", ...)`) ; a regra de negócio encerra o vínculo anterior com `dt_fim = CURRENT_DATE` ao criar novo vínculo no mesmo `codgrp`.
- Cria frontend React + MUI incluindo novo menu **Compradores** posicionado entre *Comissões* e *Controladoria*, novas rotas e 3 telas: `Compradores`, `Grupos` e `Metas`, além do service `frontend/src/services/compradoresService.ts` para consumir a API.
- Principais arquivos alterados/adicionados: `backend/sql/compradores.sql`, `backend/src/services/compradoresService.ts`, `backend/src/controllers/compradoresController.ts`, `backend/src/routes/compradoresRoutes.ts`, `backend/src/app.ts`, `frontend/src/components/Layout.tsx`, `frontend/src/App.tsx`, `frontend/src/pages/Compradores.tsx`, `frontend/src/pages/CompradoresGrupos.tsx`, `frontend/src/pages/CompradoresMetas.tsx` e `frontend/src/services/compradoresService.ts`.

### Testing

- Executado `cd backend && npm run build` para compilar o backend TypeScript e a compilação foi concluída com sucesso. 
- Executado `cd frontend && npm run build` para gerar o bundle do frontend e o build foi concluído com sucesso com avisos de ESLint/React Hooks (warnings existentes no projeto e aviso de hook em `CompradoresMetas`).
- Não foram alterados testes automatizados além dos builds de `tsc`/`react-scripts` executados, e ambos os builds terminaram com exit code 0.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c4d41ae48324ba5a55c0dd5550da)