### PR TITLE
Padroniza visual e adiciona CRUD completo em Compradores, Grupos e Metas

### DIFF
--- a/frontend/src/pages/Compradores.tsx
+++ b/frontend/src/pages/Compradores.tsx
@@ -1,24 +1,74 @@
-import { Box, Button, Switch, TextField, Typography } from "@mui/material"
+import { Delete as DeleteIcon, Edit as EditIcon, Refresh as RefreshIcon, Save as SaveIcon } from "@mui/icons-material"
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  IconButton,
+  Paper,
+  Snackbar,
+  Switch,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from "@mui/material"
 import { useEffect, useState } from "react"
-import { criarComprador, excluirComprador, listarCompradores } from "../services/compradoresService"
+import { atualizarComprador, criarComprador, excluirComprador, listarCompradores } from "../services/compradoresService"
 
 export default function Compradores() {
   const [nome, setNome] = useState("")
   const [ativo, setAtivo] = useState(true)
   const [itens, setItens] = useState<any[]>([])
-  const carregar = async () => setItens(await listarCompradores())
+  const [editandoId, setEditandoId] = useState<number | null>(null)
+  const [editNome, setEditNome] = useState("")
+  const [editAtivo, setEditAtivo] = useState(true)
+  const [loading, setLoading] = useState(true)
+  const [snackbar, setSnackbar] = useState({ open: false, message: "", severity: "success" as "success" | "error" })
+
+  const carregar = async () => {
+    setLoading(true)
+    try { setItens(await listarCompradores()) } finally { setLoading(false) }
+  }
+
   useEffect(() => { carregar() }, [])
 
   return <Box>
-    <Typography variant="h5">Compradores</Typography>
-    <Box sx={{ display: "flex", gap: 2, my: 2 }}>
-      <TextField label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} />
-      <Box sx={{ display: "flex", alignItems: "center" }}>Ativo <Switch checked={ativo} onChange={(_, v) => setAtivo(v)} /></Box>
-      <Button variant="contained" onClick={async () => { await criarComprador({ nome, ativo }); setNome(""); carregar() }}>Salvar</Button>
+    <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 2 }}>
+      <Typography variant="h5" fontWeight={700}>Compradores</Typography>
+      <Button startIcon={<RefreshIcon />} variant="outlined" onClick={carregar}>Atualizar</Button>
     </Box>
-    {itens.map((c) => <Box key={c.id} sx={{ display: "flex", gap: 2, py: 1 }}>
-      <Typography>{c.nome}</Typography><Typography>{c.ativo ? "Ativo" : "Inativo"}</Typography>
-      <Button color="error" onClick={async () => { await excluirComprador(c.id); carregar() }}>Excluir</Button>
-    </Box>)}
+
+    <Paper sx={{ p: 2, mb: 3 }}>
+      <Typography variant="subtitle1" fontWeight={600} sx={{ mb: 2 }}>Novo comprador</Typography>
+      <Box sx={{ display: "flex", gap: 2, alignItems: "center", flexWrap: "wrap" }}>
+        <TextField label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} size="small" sx={{ minWidth: 280 }} />
+        <Box sx={{ display: "flex", alignItems: "center" }}>Ativo <Switch checked={ativo} onChange={(_, v) => setAtivo(v)} /></Box>
+        <Button variant="contained" onClick={async () => { await criarComprador({ nome, ativo }); setNome(""); setAtivo(true); carregar() }}>Salvar</Button>
+      </Box>
+    </Paper>
+
+    <TableContainer component={Paper}>
+      <Table size="small">
+        <TableHead><TableRow><TableCell>Nome</TableCell><TableCell>Ativo</TableCell><TableCell align="right">Ações</TableCell></TableRow></TableHead>
+        <TableBody>
+          {loading && <TableRow><TableCell colSpan={3} align="center"><CircularProgress size={24} /></TableCell></TableRow>}
+          {!loading && itens.map((c) => <TableRow key={c.id}>
+            <TableCell>{editandoId === c.id ? <TextField size="small" value={editNome} onChange={(e) => setEditNome(e.target.value)} /> : c.nome}</TableCell>
+            <TableCell>{editandoId === c.id ? <Switch checked={editAtivo} onChange={(_, v) => setEditAtivo(v)} /> : (c.ativo ? "Sim" : "Não")}</TableCell>
+            <TableCell align="right">
+              {editandoId === c.id ? <IconButton color="primary" onClick={async () => { await atualizarComprador(c.id, { nome: editNome, ativo: editAtivo }); setEditandoId(null); carregar(); }}><SaveIcon /></IconButton> : <IconButton color="primary" onClick={() => { setEditandoId(c.id); setEditNome(c.nome); setEditAtivo(c.ativo) }}><EditIcon /></IconButton>}
+              <IconButton color="error" onClick={async () => { await excluirComprador(c.id); carregar(); setSnackbar({ open: true, message: "Comprador excluído.", severity: "success" }) }}><DeleteIcon /></IconButton>
+            </TableCell>
+          </TableRow>)}
+        </TableBody>
+      </Table>
+    </TableContainer>
+
+    <Snackbar open={snackbar.open} autoHideDuration={3000} onClose={() => setSnackbar((s) => ({ ...s, open: false }))}><Alert severity={snackbar.severity}>{snackbar.message}</Alert></Snackbar>
   </Box>
 }

--- a/frontend/src/pages/CompradoresGrupos.tsx
+++ b/frontend/src/pages/CompradoresGrupos.tsx
@@ -1,27 +1,42 @@
-import { Box, Button, MenuItem, TextField, Typography } from "@mui/material"
+import { Delete as DeleteIcon, Edit as EditIcon, Save as SaveIcon } from "@mui/icons-material"
+import { Box, Button, IconButton, MenuItem, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, TextField, Typography } from "@mui/material"
 import { useEffect, useState } from "react"
-import { criarCompradorGrupo, listarCompradorGrupo, listarCompradores } from "../services/compradoresService"
+import { atualizarCompradorGrupo, criarCompradorGrupo, excluirCompradorGrupo, listarCompradorGrupo, listarCompradores } from "../services/compradoresService"
 
 export default function CompradoresGrupos() {
   const [compradores, setCompradores] = useState<any[]>([])
   const [vinculos, setVinculos] = useState<any[]>([])
   const [codgrp, setCodgrp] = useState("")
   const [compradorId, setCompradorId] = useState("")
-  const carregar = async () => {
-    setCompradores(await listarCompradores())
-    setVinculos(await listarCompradorGrupo())
-  }
+  const [editandoId, setEditandoId] = useState<number | null>(null)
+  const [editCodgrp, setEditCodgrp] = useState("")
+  const [editCompradorId, setEditCompradorId] = useState("")
+
+  const carregar = async () => { setCompradores(await listarCompradores()); setVinculos(await listarCompradorGrupo()) }
   useEffect(() => { carregar() }, [])
 
   return <Box>
-    <Typography variant="h5">Grupos x Compradores</Typography>
-    <Box sx={{ display: "flex", gap: 2, my: 2 }}>
-      <TextField label="Grupo (c_grp)" value={codgrp} onChange={(e) => setCodgrp(e.target.value)} inputProps={{ maxLength: 2 }} />
-      <TextField select label="Comprador" value={compradorId} onChange={(e) => setCompradorId(e.target.value)} sx={{ minWidth: 260 }}>
-        {compradores.map((c) => <MenuItem key={c.id} value={c.id}>{c.nome}</MenuItem>)}
-      </TextField>
-      <Button variant="contained" onClick={async () => { await criarCompradorGrupo({ codgrp, comprador_id: Number(compradorId) }); carregar() }}>Vincular</Button>
-    </Box>
-    {vinculos.map((v) => <Typography key={v.id}>{v.codgrp} - {v.comprador_nome} ({v.dt_fim ? "Histórico" : "Atual"})</Typography>)}
+    <Typography variant="h5" fontWeight={700} sx={{ mb: 2 }}>Grupos x Compradores</Typography>
+    <Paper sx={{ p: 2, mb: 3 }}>
+      <Typography variant="subtitle1" fontWeight={600} sx={{ mb: 2 }}>Novo vínculo</Typography>
+      <Box sx={{ display: "flex", gap: 2, my: 1, flexWrap: "wrap" }}>
+        <TextField label="Grupo (c_grp)" value={codgrp} onChange={(e) => setCodgrp(e.target.value)} inputProps={{ maxLength: 2 }} size="small" />
+        <TextField select label="Comprador" value={compradorId} onChange={(e) => setCompradorId(e.target.value)} sx={{ minWidth: 280 }} size="small">
+          {compradores.map((c) => <MenuItem key={c.id} value={c.id}>{c.nome}</MenuItem>)}
+        </TextField>
+        <Button variant="contained" onClick={async () => { await criarCompradorGrupo({ codgrp, comprador_id: Number(compradorId) }); setCodgrp(""); setCompradorId(""); carregar() }}>Salvar</Button>
+      </Box>
+    </Paper>
+    <TableContainer component={Paper}><Table size="small"><TableHead><TableRow><TableCell>Grupo</TableCell><TableCell>Comprador</TableCell><TableCell>Status</TableCell><TableCell align="right">Ações</TableCell></TableRow></TableHead><TableBody>
+      {vinculos.map((v) => <TableRow key={v.id}>
+        <TableCell>{editandoId === v.id ? <TextField value={editCodgrp} size="small" onChange={(e) => setEditCodgrp(e.target.value)} /> : v.codgrp}</TableCell>
+        <TableCell>{editandoId === v.id ? <TextField select size="small" value={editCompradorId} onChange={(e) => setEditCompradorId(e.target.value)} sx={{ minWidth: 220 }}>{compradores.map((c) => <MenuItem key={c.id} value={c.id}>{c.nome}</MenuItem>)}</TextField> : v.comprador_nome}</TableCell>
+        <TableCell>{v.dt_fim ? "Inativo" : "Ativo"}</TableCell>
+        <TableCell align="right">
+          {editandoId === v.id ? <IconButton color="primary" onClick={async () => { await atualizarCompradorGrupo(v.id, { codgrp: editCodgrp, comprador_id: Number(editCompradorId) }); setEditandoId(null); carregar() }}><SaveIcon /></IconButton> : <IconButton color="primary" onClick={() => { setEditandoId(v.id); setEditCodgrp(v.codgrp); setEditCompradorId(String(v.comprador_id ?? "")) }}><EditIcon /></IconButton>}
+          <IconButton color="error" onClick={async () => { await excluirCompradorGrupo(v.id); carregar() }}><DeleteIcon /></IconButton>
+        </TableCell>
+      </TableRow>)}
+    </TableBody></Table></TableContainer>
   </Box>
 }

--- a/frontend/src/pages/CompradoresMetas.tsx
+++ b/frontend/src/pages/CompradoresMetas.tsx
@@ -1,6 +1,7 @@
-import { Box, Button, MenuItem, TextField, Typography } from "@mui/material"
+import { Delete as DeleteIcon, Save as SaveIcon } from "@mui/icons-material"
+import { Box, Button, IconButton, MenuItem, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, TextField, Typography } from "@mui/material"
 import { useEffect, useState } from "react"
-import { listarCompradores, listarMetasCompradores, salvarMetaComprador } from "../services/compradoresService"
+import { excluirMetaComprador, listarCompradores, listarMetasCompradores, salvarMetaComprador } from "../services/compradoresService"
 
 export default function CompradoresMetas() {
   const [ano, setAno] = useState(new Date().getFullYear())
@@ -8,6 +9,8 @@ export default function CompradoresMetas() {
   const [compradorId, setCompradorId] = useState("")
   const [compradores, setCompradores] = useState<any[]>([])
   const [metas, setMetas] = useState<any[]>([])
+  const [novo, setNovo] = useState<any>({ codgrp: "", comprador_id: "", meta_vendas: 0, meta_lb: 0, meta_evolucao: 0, meta_nivel_servico: 0, meta_dias_estoque: 0, meta_produtos_fora: 0 })
+
   const carregar = async () => {
     setMetas(await listarMetasCompradores({ ano, mes, comprador_id: compradorId || undefined }))
     setCompradores(await listarCompradores())
@@ -15,24 +18,37 @@ export default function CompradoresMetas() {
   useEffect(() => { carregar() }, [])
 
   return <Box>
-    <Typography variant="h5">Metas de Compradores</Typography>
-    <Box sx={{ display: "flex", gap: 2, my: 2 }}>
-      <TextField label="Ano" type="number" value={ano} onChange={(e) => setAno(Number(e.target.value))} />
-      <TextField label="Mês" type="number" value={mes} onChange={(e) => setMes(Number(e.target.value))} />
-      <TextField select label="Comprador" value={compradorId} onChange={(e) => setCompradorId(e.target.value)} sx={{ minWidth: 250 }}>
-        <MenuItem value="">Todos</MenuItem>
-        {compradores.map((c) => <MenuItem key={c.id} value={c.id}>{c.nome}</MenuItem>)}
-      </TextField>
-      <Button variant="outlined" onClick={carregar}>Filtrar</Button>
-    </Box>
-    {metas.map((m) => <Box key={m.id} sx={{ display: "flex", gap: 1, my: 1 }}>
-      <Typography sx={{ minWidth: 90 }}>{m.codgrp}</Typography>
-      <TextField size="small" label="Vendas" defaultValue={m.meta_vendas} onBlur={async (e) => await salvarMetaComprador({ ...m, meta_vendas: Number(e.target.value) })} />
-      <TextField size="small" label="LB" defaultValue={m.meta_lb} onBlur={async (e) => await salvarMetaComprador({ ...m, meta_lb: Number(e.target.value) })} />
-      <TextField size="small" label="Evolução" defaultValue={m.meta_evolucao} onBlur={async (e) => await salvarMetaComprador({ ...m, meta_evolucao: Number(e.target.value) })} />
-      <TextField size="small" label="Nível Serviço" defaultValue={m.meta_nivel_servico} onBlur={async (e) => await salvarMetaComprador({ ...m, meta_nivel_servico: Number(e.target.value) })} />
-      <TextField size="small" label="Dias Estoque" defaultValue={m.meta_dias_estoque} onBlur={async (e) => await salvarMetaComprador({ ...m, meta_dias_estoque: Number(e.target.value) })} />
-      <TextField size="small" label="Prod. Fora" defaultValue={m.meta_produtos_fora} onBlur={async (e) => await salvarMetaComprador({ ...m, meta_produtos_fora: Number(e.target.value) })} />
-    </Box>)}
+    <Typography variant="h5" fontWeight={700} sx={{ mb: 2 }}>Metas de Compradores</Typography>
+    <Paper sx={{ p: 2, mb: 2 }}>
+      <Box sx={{ display: "flex", gap: 2, alignItems: "center", flexWrap: "wrap" }}>
+        <TextField label="Ano" type="number" size="small" value={ano} onChange={(e) => setAno(Number(e.target.value))} />
+        <TextField label="Mês" type="number" size="small" value={mes} onChange={(e) => setMes(Number(e.target.value))} />
+        <TextField select label="Comprador" size="small" value={compradorId} onChange={(e) => setCompradorId(e.target.value)} sx={{ minWidth: 250 }}>
+          <MenuItem value="">Todos</MenuItem>{compradores.map((c) => <MenuItem key={c.id} value={c.id}>{c.nome}</MenuItem>)}
+        </TextField>
+        <Button variant="outlined" onClick={carregar}>Filtrar</Button>
+      </Box>
+    </Paper>
+
+    <Paper sx={{ p: 2, mb: 2 }}>
+      <Typography variant="subtitle1" fontWeight={600} sx={{ mb: 1 }}>Nova meta</Typography>
+      <Box sx={{ display: "grid", gridTemplateColumns: "repeat(4, minmax(150px, 1fr))", gap: 1 }}>
+        <TextField label="Grupo" size="small" value={novo.codgrp} onChange={(e) => setNovo({ ...novo, codgrp: e.target.value })} />
+        <TextField select label="Comprador" size="small" value={novo.comprador_id} onChange={(e) => setNovo({ ...novo, comprador_id: e.target.value })}>{compradores.map((c) => <MenuItem key={c.id} value={c.id}>{c.nome}</MenuItem>)}</TextField>
+        {['meta_vendas','meta_lb','meta_evolucao','meta_nivel_servico','meta_dias_estoque','meta_produtos_fora'].map((k) => <TextField key={k} label={k} size="small" type="number" value={novo[k]} onChange={(e) => setNovo({ ...novo, [k]: Number(e.target.value) })} />)}
+      </Box>
+      <Button sx={{ mt: 1 }} variant="contained" onClick={async () => { await salvarMetaComprador({ ...novo, ano, mes, comprador_id: Number(novo.comprador_id) }); carregar() }}>Salvar</Button>
+    </Paper>
+
+    <TableContainer component={Paper}><Table size="small"><TableHead><TableRow><TableCell>Grupo</TableCell><TableCell>Comprador</TableCell><TableCell>Vendas</TableCell><TableCell>LB</TableCell><TableCell>Evol.</TableCell><TableCell>N. Serviço</TableCell><TableCell>Dias Est.</TableCell><TableCell>Prod Fora</TableCell><TableCell align="right">Ações</TableCell></TableRow></TableHead><TableBody>
+      {metas.map((m) => <TableRow key={m.id}><TableCell>{m.codgrp}</TableCell><TableCell>{m.comprador_nome}</TableCell>
+        <TableCell><TextField size="small" type="number" defaultValue={m.meta_vendas} onBlur={async (e) => await salvarMetaComprador({ ...m, meta_vendas: Number(e.target.value) })} /></TableCell>
+        <TableCell><TextField size="small" type="number" defaultValue={m.meta_lb} onBlur={async (e) => await salvarMetaComprador({ ...m, meta_lb: Number(e.target.value) })} /></TableCell>
+        <TableCell><TextField size="small" type="number" defaultValue={m.meta_evolucao} onBlur={async (e) => await salvarMetaComprador({ ...m, meta_evolucao: Number(e.target.value) })} /></TableCell>
+        <TableCell><TextField size="small" type="number" defaultValue={m.meta_nivel_servico} onBlur={async (e) => await salvarMetaComprador({ ...m, meta_nivel_servico: Number(e.target.value) })} /></TableCell>
+        <TableCell><TextField size="small" type="number" defaultValue={m.meta_dias_estoque} onBlur={async (e) => await salvarMetaComprador({ ...m, meta_dias_estoque: Number(e.target.value) })} /></TableCell>
+        <TableCell><TextField size="small" type="number" defaultValue={m.meta_produtos_fora} onBlur={async (e) => await salvarMetaComprador({ ...m, meta_produtos_fora: Number(e.target.value) })} /></TableCell>
+        <TableCell align="right"><IconButton color="primary" onClick={async () => carregar()}><SaveIcon /></IconButton><IconButton color="error" onClick={async () => { await excluirMetaComprador(m.id); carregar() }}><DeleteIcon /></IconButton></TableCell></TableRow>)}
+    </TableBody></Table></TableContainer>
   </Box>
 }

--- a/frontend/src/services/compradoresService.ts
+++ b/frontend/src/services/compradoresService.ts
@@ -7,8 +7,12 @@ export const excluirComprador = async (id: number) => (await api.delete(`/compra
 
 export const listarCompradorGrupo = async () => (await api.get("/comprador-grupo")).data
 export const criarCompradorGrupo = async (payload: any) => (await api.post("/comprador-grupo", payload)).data
+export const atualizarCompradorGrupo = async (id: number, payload: any) =>
+  (await api.put(`/comprador-grupo/${id}`, payload)).data
+export const excluirCompradorGrupo = async (id: number) => (await api.delete(`/comprador-grupo/${id}`)).data
 
 export const listarMetasCompradores = async (params: any) => (await api.get("/metas-compradores", { params })).data
 export const salvarMetaComprador = async (meta: any) => meta.id
   ? (await api.put(`/metas-compradores/${meta.id}`, meta)).data
   : (await api.post("/metas-compradores", meta)).data
+export const excluirMetaComprador = async (id: number) => (await api.delete(`/metas-compradores/${id}`)).data


### PR DESCRIPTION
### Motivation
- Uniformizar as telas de Compradores, Grupos x Compradores e Metas de Compradores com o padrão visual usado nas demais páginas para melhorar consistência e usabilidade.
- Habilitar operações completas de manutenção (CRUD) nas três áreas que antes ofereciam apenas funções parciais ou listagens simples.
- Completar o service para expor endpoints de atualização/exclusão necessários ao fluxo de UI.

### Description
- Padronizei a UI usando `Paper`, `Table`, cabeçalhos com `Typography` e ações por ícone em `Compradores`, `CompradoresGrupos` e `CompradoresMetas`.
- Implementei CRUD em `Compradores` com criação, listagem, edição inline, exclusão, loading e `Snackbar` de feedback (file: `frontend/src/pages/Compradores.tsx`).
- Implementei CRUD em `Grupos x Compradores` com criação, listagem, edição inline e exclusão, integrando `atualizarCompradorGrupo` e `excluirCompradorGrupo` (file: `frontend/src/pages/CompradoresGrupos.tsx`).
- Implementei criação/filtragem/atualização por campo (onBlur) e exclusão de metas, além de um formulário de nova meta (file: `frontend/src/pages/CompradoresMetas.tsx`).
- Estendi o service `frontend/src/services/compradoresService.ts` adicionando `atualizarCompradorGrupo`, `excluirCompradorGrupo` e `excluirMetaComprador`, além de usar `atualizarComprador` existente.

### Testing
- Executei o build do frontend com `cd frontend && npm run build` e a compilação finalizou com sucesso (build pronta para deploy).
- O build exibiu apenas warnings de lint e hooks (`react-hooks/exhaustive-deps`) já presentes/no caso não bloqueantes, incluindo um aviso novo relacionado a dependência de hook em `CompradoresMetas.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c9c2bf9c8324bfa1ecf4b8ae5715)