### PR TITLE
feat: dashboard público TV Compras (KPIs percentuais, sem autenticação)

### DIFF
--- a/backend/sql/dashboard_tv_compras.sql
+++ b/backend/sql/dashboard_tv_compras.sql
@@ -1,0 +1,45 @@
+-- Dashboard TV Compras (somente indicadores percentuais, sem exposição de valores em R$)
+WITH params AS (
+  SELECT EXTRACT(YEAR FROM CURRENT_DATE)::int AS ano_atual,
+         EXTRACT(MONTH FROM CURRENT_DATE)::int AS mes_atual
+),
+base AS (
+  SELECT
+    v.codgrp,
+    c.nome AS comprador,
+    EXTRACT(YEAR FROM v.datamov)::int AS ano,
+    EXTRACT(MONTH FROM v.datamov)::int AS mes,
+    SUM(COALESCE(v.vlr_total_vendas_bruta,0)) AS venda_bruta,
+    SUM(COALESCE(v.vlr_total_devolucoes,0)) AS devolucao,
+    SUM(COALESCE(v.vlr_custos_vendas,0)) AS custos,
+    SUM(COALESCE(v.vlr_impostos_vendas,0)) AS impostos
+  FROM vs_scc_vendas_devolucoes v
+  JOIN scc_comprador_grupo cg ON cg.codgrp = v.codgrp AND cg.dt_fim IS NULL
+  JOIN scc_compradores c ON c.id = cg.comprador_id
+  GROUP BY v.codgrp, c.nome, EXTRACT(YEAR FROM v.datamov), EXTRACT(MONTH FROM v.datamov)
+),
+curr AS (
+  SELECT b.*, (b.venda_bruta - b.devolucao) AS venda,
+         (b.venda_bruta - b.custos - b.impostos) AS lb
+  FROM base b JOIN params p ON b.ano = p.ano_atual AND b.mes = p.mes_atual
+),
+prev_year AS (
+  SELECT b.codgrp, (b.venda_bruta - b.devolucao) AS venda_prev
+  FROM base b JOIN params p ON b.ano = p.ano_atual - 1 AND b.mes = p.mes_atual
+),
+meta AS (
+  SELECT m.codgrp, m.meta_vendas, m.meta_lb
+  FROM scc_metas_compradores m
+  JOIN params p ON m.ano = p.ano_atual AND m.mes = p.mes_atual
+)
+SELECT
+  c.codgrp,
+  c.comprador,
+  CASE WHEN COALESCE(m.meta_vendas,0) = 0 THEN 0 ELSE (c.venda / m.meta_vendas) * 100 END AS venda_percentual_meta,
+  CASE WHEN c.venda = 0 THEN 0 ELSE (c.lb / c.venda) * 100 END AS lb_percentual,
+  COALESCE(m.meta_lb, 0) AS meta_lb,
+  CASE WHEN COALESCE(py.venda_prev,0) = 0 THEN 0 ELSE ((c.venda / py.venda_prev) - 1) * 100 END AS evolucao_percentual
+FROM curr c
+LEFT JOIN prev_year py ON py.codgrp = c.codgrp
+LEFT JOIN meta m ON m.codgrp = c.codgrp
+ORDER BY venda_percentual_meta ASC, c.comprador;

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -10,6 +10,7 @@ import controleAcessoRoutes from "./routes/controleAcessoRoutes"
 import dreRoutes from "./routes/dreRoutes"
 import helpDeskRoutes from "./routes/helpDeskRoutes"
 import compradoresRoutes from "./routes/compradoresRoutes"
+import dashboardTvComprasRoutes from "./routes/dashboardTvComprasRoutes"
 import { corsMiddleware } from "./config/cors"
 
 // Carrega as variáveis de ambiente antes de qualquer outra operação
@@ -33,6 +34,7 @@ app.use("/api/controle-acesso", controleAcessoRoutes)
 app.use("/api/dre", dreRoutes)
 app.use("/api/help-desk", helpDeskRoutes)
 app.use("/api", compradoresRoutes)
+app.use("/", dashboardTvComprasRoutes)
 
 // Rota de teste para verificar se o servidor está funcionando
 app.get("/", (req, res) => {

--- a/backend/src/controllers/dashboardTvComprasController.ts
+++ b/backend/src/controllers/dashboardTvComprasController.ts
@@ -1,0 +1,12 @@
+import type { Request, Response } from "express"
+import { getDashboardTvCompras } from "../services/dashboardTvComprasService"
+
+export const dashboardTvCompras = async (_req: Request, res: Response) => {
+  try {
+    const data = await getDashboardTvCompras()
+    res.json(data)
+  } catch (error) {
+    console.error("Erro ao gerar dashboard TV compras:", error)
+    res.status(500).json({ message: "Erro ao gerar dashboard de compras para TV." })
+  }
+}

--- a/backend/src/routes/dashboardTvComprasRoutes.ts
+++ b/backend/src/routes/dashboardTvComprasRoutes.ts
@@ -1,0 +1,8 @@
+import { Router } from "express"
+import { dashboardTvCompras } from "../controllers/dashboardTvComprasController"
+
+const router = Router()
+
+router.get("/dashboard-tv-compras", dashboardTvCompras)
+
+export default router

--- a/backend/src/services/dashboardTvComprasService.ts
+++ b/backend/src/services/dashboardTvComprasService.ts
@@ -1,0 +1,106 @@
+import pool from "../config/database"
+
+const safePercent = (value: number | null | undefined) => Number.isFinite(value as number) ? Number(value) : 0
+
+export const getDashboardTvCompras = async () => {
+  const query = `
+    WITH params AS (
+      SELECT EXTRACT(YEAR FROM CURRENT_DATE)::int AS ano_atual,
+             EXTRACT(MONTH FROM CURRENT_DATE)::int AS mes_atual
+    ),
+    base AS (
+      SELECT
+        v.codgrp,
+        c.nome AS comprador,
+        EXTRACT(YEAR FROM v.datamov)::int AS ano,
+        EXTRACT(MONTH FROM v.datamov)::int AS mes,
+        SUM(COALESCE(v.vlr_total_vendas_bruta,0)) AS venda_bruta,
+        SUM(COALESCE(v.vlr_total_devolucoes,0)) AS devolucao,
+        SUM(COALESCE(v.vlr_custos_vendas,0)) AS custos,
+        SUM(COALESCE(v.vlr_impostos_vendas,0)) AS impostos
+      FROM vs_scc_vendas_devolucoes v
+      JOIN scc_comprador_grupo cg ON cg.codgrp = v.codgrp AND cg.dt_fim IS NULL
+      JOIN scc_compradores c ON c.id = cg.comprador_id
+      GROUP BY v.codgrp, c.nome, EXTRACT(YEAR FROM v.datamov), EXTRACT(MONTH FROM v.datamov)
+    ),
+    curr AS (
+      SELECT b.*, (b.venda_bruta - b.devolucao) AS venda,
+             (b.venda_bruta - b.custos - b.impostos) AS lb
+      FROM base b JOIN params p ON b.ano = p.ano_atual AND b.mes = p.mes_atual
+    ),
+    prev_year AS (
+      SELECT b.codgrp, (b.venda_bruta - b.devolucao) AS venda_prev
+      FROM base b JOIN params p ON b.ano = p.ano_atual - 1 AND b.mes = p.mes_atual
+    ),
+    meta AS (
+      SELECT m.codgrp, m.meta_vendas, m.meta_lb
+      FROM scc_metas_compradores m
+      JOIN params p ON m.ano = p.ano_atual AND m.mes = p.mes_atual
+    )
+    SELECT
+      c.codgrp,
+      c.comprador,
+      c.venda,
+      c.lb,
+      CASE WHEN c.venda = 0 THEN 0 ELSE (c.lb / c.venda) * 100 END AS lb_percentual,
+      CASE WHEN COALESCE(m.meta_vendas,0) = 0 THEN 0 ELSE (c.venda / m.meta_vendas) * 100 END AS venda_percentual_meta,
+      COALESCE(m.meta_lb, 0) AS meta_lb,
+      CASE WHEN COALESCE(py.venda_prev,0) = 0 THEN 0 ELSE ((c.venda / py.venda_prev) - 1) * 100 END AS evolucao_percentual
+    FROM curr c
+    LEFT JOIN prev_year py ON py.codgrp = c.codgrp
+    LEFT JOIN meta m ON m.codgrp = c.codgrp
+    ORDER BY venda_percentual_meta ASC, c.comprador;
+  `
+
+  const result = await pool.query(query)
+  const compradores = result.rows.map((row) => {
+    const vendaMeta = safePercent(row.venda_percentual_meta)
+    const lbPct = safePercent(row.lb_percentual)
+    const metaLb = safePercent(row.meta_lb)
+    const evolucao = safePercent(row.evolucao_percentual)
+
+    let status = "ABAIXO"
+    if (vendaMeta >= 100) status = "ACIMA DA META"
+    else if (vendaMeta >= 95) status = "ATENÇÃO"
+
+    return {
+      comprador: row.comprador,
+      grupo: row.codgrp,
+      vendaPercentualMeta: Number(vendaMeta.toFixed(2)),
+      lbPercentual: Number(lbPct.toFixed(2)),
+      metaLb: Number(metaLb.toFixed(2)),
+      evolucaoPercentual: Number(evolucao.toFixed(2)),
+      status,
+    }
+  })
+
+  const total = compradores.length || 1
+  const media = (arr: number[]) => arr.reduce((sum, value) => sum + value, 0) / total
+
+  const kpis = {
+    vendasAtingimento: Number(media(compradores.map((c) => c.vendaPercentualMeta)).toFixed(2)),
+    lbRealizado: Number(media(compradores.map((c) => c.lbPercentual)).toFixed(2)),
+    lbMeta: Number(media(compradores.map((c) => c.metaLb)).toFixed(2)),
+    evolucao: Number(media(compradores.map((c) => c.evolucaoPercentual)).toFixed(2)),
+    nivelServico: null,
+    diasEstoque: null,
+    produtosFora: null,
+  }
+
+  const alertas: string[] = []
+  compradores.forEach((c) => {
+    if (c.lbPercentual < c.metaLb) alertas.push(`${c.comprador}: LB abaixo da meta.`)
+    if (c.vendaPercentualMeta < 90) alertas.push(`${c.comprador}: Venda abaixo de 90%.`)
+    if (c.evolucaoPercentual < 0) alertas.push(`${c.comprador}: Queda versus mesmo mês do ano anterior.`)
+  })
+
+  return {
+    kpis,
+    compradores,
+    graficos: {
+      evolucaoVendas: compradores.map((c) => ({ label: c.comprador, valor: c.vendaPercentualMeta })),
+      evolucaoLb: compradores.map((c) => ({ label: c.comprador, valor: c.lbPercentual })),
+    },
+    alertas,
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,7 @@ import { ThemeProvider } from "./contexts/ThemeContext"
 import Compradores from "./pages/Compradores"
 import CompradoresGrupos from "./pages/CompradoresGrupos"
 import CompradoresMetas from "./pages/CompradoresMetas"
+import TvCompras from "./pages/TvCompras"
 
 function App() {
   console.log("App renderizando")
@@ -36,6 +37,7 @@ function App() {
         <AuthProvider>
           <Routes>
             <Route path="/login" element={<Login />} />
+            <Route path="/tv-compras" element={<TvCompras />} />
             <Route
               path="/"
               element={

--- a/frontend/src/pages/TvCompras.tsx
+++ b/frontend/src/pages/TvCompras.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useMemo, useState } from "react"
+import {
+  Alert,
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  Grid,
+  LinearProgress,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material"
+import { getDashboardTvCompras } from "../services/dashboardTvComprasService"
+
+const statusColor = (v: number) => (v >= 100 ? "success" : v >= 95 ? "warning" : "error")
+
+export default function TvCompras() {
+  const [data, setData] = useState<any>({ kpis: {}, compradores: [], graficos: { evolucaoVendas: [], evolucaoLb: [] }, alertas: [] })
+
+  const fetchDados = async () => {
+    try {
+      const response = await getDashboardTvCompras()
+      setData(response)
+    } catch (error) {
+      console.error("Erro ao buscar dashboard TV compras", error)
+    }
+  }
+
+  useEffect(() => {
+    fetchDados()
+    const timer = setInterval(() => {
+      fetchDados()
+    }, 60000)
+
+    return () => clearInterval(timer)
+  }, [])
+
+  const kpis = useMemo(
+    () => [
+      { label: "Vendas (% Meta)", value: data.kpis?.vendasAtingimento ?? 0 },
+      { label: "LB (% Realizado)", value: data.kpis?.lbRealizado ?? 0 },
+      { label: "Evolução (%)", value: data.kpis?.evolucao ?? 0 },
+      { label: "Nível de Serviço", value: null },
+      { label: "Dias de Estoque", value: null },
+      { label: "Produtos Fora", value: null },
+    ],
+    [data.kpis],
+  )
+
+  return (
+    <Box sx={{ minHeight: "100vh", background: "#050816", color: "#fff", p: 3 }}>
+      <Typography variant="h3" fontWeight={700} mb={2}>Dashboard TV Compras</Typography>
+      <Grid container spacing={2} mb={2}>
+        {kpis.map((kpi: any) => (
+          <Grid item xs={12} md={4} lg={2} key={kpi.label}>
+            <Card sx={{ background: "#111827", borderRadius: 3 }}>
+              <CardContent>
+                <Typography variant="subtitle2" color="#9CA3AF">{kpi.label}</Typography>
+                <Typography variant="h4" fontWeight={800}>{kpi.value === null ? "--" : `${Number(kpi.value).toFixed(2)}%`}</Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+
+      <Grid container spacing={2} mb={2}>
+        <Grid item xs={12} md={6}>
+          <Card sx={{ background: "#111827", p: 2, borderRadius: 3 }}>
+            <Typography variant="h6" mb={1}>Evolução de Vendas (%)</Typography>
+            <Stack spacing={1}>
+              {data.graficos?.evolucaoVendas?.map((item: any) => (
+                <Box key={item.label}>
+                  <Typography variant="body2">{item.label} - {Number(item.valor).toFixed(1)}%</Typography>
+                  <LinearProgress variant="determinate" value={Math.max(0, Math.min(100, item.valor))} color={statusColor(item.valor)} />
+                </Box>
+              ))}
+            </Stack>
+          </Card>
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <Card sx={{ background: "#111827", p: 2, borderRadius: 3 }}>
+            <Typography variant="h6" mb={1}>Evolução de LB (%)</Typography>
+            <Stack spacing={1}>
+              {data.graficos?.evolucaoLb?.map((item: any) => (
+                <Box key={item.label}>
+                  <Typography variant="body2">{item.label} - {Number(item.valor).toFixed(1)}%</Typography>
+                  <LinearProgress variant="determinate" value={Math.max(0, Math.min(100, item.valor))} color={statusColor(item.valor)} />
+                </Box>
+              ))}
+            </Stack>
+          </Card>
+        </Grid>
+      </Grid>
+
+      <Card sx={{ background: "#111827", borderRadius: 3, mb: 2 }}>
+        <CardContent>
+          <Typography variant="h6" mb={1}>Performance por Comprador</Typography>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell sx={{ color: "#fff" }}>Comprador</TableCell><TableCell sx={{ color: "#fff" }}>Grupo</TableCell>
+                <TableCell sx={{ color: "#fff" }}>Venda (% Meta)</TableCell><TableCell sx={{ color: "#fff" }}>LB (%)</TableCell>
+                <TableCell sx={{ color: "#fff" }}>Meta LB (%)</TableCell><TableCell sx={{ color: "#fff" }}>Evolução (%)</TableCell><TableCell sx={{ color: "#fff" }}>Status</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {data.compradores?.map((c: any) => (
+                <TableRow key={`${c.grupo}-${c.comprador}`}>
+                  <TableCell sx={{ color: "#E5E7EB" }}>{c.comprador}</TableCell><TableCell sx={{ color: "#E5E7EB" }}>{c.grupo}</TableCell>
+                  <TableCell sx={{ color: "#E5E7EB" }}>{c.vendaPercentualMeta.toFixed(2)}%</TableCell><TableCell sx={{ color: "#E5E7EB" }}>{c.lbPercentual.toFixed(2)}%</TableCell>
+                  <TableCell sx={{ color: "#E5E7EB" }}>{c.metaLb.toFixed(2)}%</TableCell><TableCell sx={{ color: "#E5E7EB" }}>{c.evolucaoPercentual.toFixed(2)}%</TableCell>
+                  <TableCell><Chip label={c.status} color={statusColor(c.vendaPercentualMeta)} /></TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <Card sx={{ background: "#111827", borderRadius: 3 }}>
+        <CardContent>
+          <Typography variant="h6" mb={1}>Alertas</Typography>
+          <Stack spacing={1}>
+            {data.alertas?.length ? data.alertas.map((alerta: string, idx: number) => <Alert key={idx} severity="warning">{alerta}</Alert>) : <Alert severity="success">Sem alertas críticos no momento.</Alert>}
+          </Stack>
+        </CardContent>
+      </Card>
+    </Box>
+  )
+}

--- a/frontend/src/services/dashboardTvComprasService.ts
+++ b/frontend/src/services/dashboardTvComprasService.ts
@@ -1,0 +1,16 @@
+import axios from "axios"
+
+const getPublicApiBase = () => {
+  const configuredBaseUrl = process.env.REACT_APP_API_URL?.trim()
+  if (configuredBaseUrl) return configuredBaseUrl.replace(/\/api\/?$/, "")
+  if (typeof window !== "undefined") {
+    const { hostname, protocol } = window.location
+    return `${protocol}//${hostname}:8601`
+  }
+  return "http://localhost:8601"
+}
+
+export const getDashboardTvCompras = async () => {
+  const response = await axios.get(`${getPublicApiBase()}/dashboard-tv-compras`)
+  return response.data
+}


### PR DESCRIPTION
### Motivation
- Fornecer uma tela fullscreen para TV que mostre indicadores de compras focados em percentuais e alertas, sem exigir autenticação e sem expor valores monetários.
- Agregar dados da view `vs_scc_vendas_devolucoes` e relacionar compradores via `scc_comprador_grupo` / `scc_compradores`, comparando com metas em `scc_metas_compradores` para suportar decisões rápidas.

### Description
- Backend: adiciona serviço de agregação `backend/src/services/dashboardTvComprasService.ts`, controller `backend/src/controllers/dashboardTvComprasController.ts` e rota pública `GET /dashboard-tv-compras` em `backend/src/routes/dashboardTvComprasRoutes.ts`, registrada em `backend/src/app.ts` na raiz (`/dashboard-tv-compras`).
- SQL: inclui consulta de referência em `backend/sql/dashboard_tv_compras.sql` que implementa as regras de negócio solicitadas (venda líquida, LB, LB%, evolução vs ano anterior e relacionamento com metas) retornando apenas percentuais e indicadores.
- Frontend: cria `frontend/src/pages/TvCompras.tsx` e `frontend/src/services/dashboardTvComprasService.ts`, registra rota pública `/tv-compras` em `frontend/src/App.tsx` e implementa UI dark fullscreen com cards de KPIs, barras de progresso, tabela de compradores, seção de alertas e placeholders para Nível de Serviço / Dias de Estoque / Produtos Fora.
- Comportamento: a API e a página não exibem valores em R$ (apenas percentuais/atingimentos), aplicam regras de status por cor e geram alertas automáticos; a página faz auto refresh a cada 60 segundos (`setInterval(..., 60000)`).

### Testing
- Executado `cd backend && npm run build` e a compilação do backend concluiu com sucesso (`tsc`).
- Executado `cd frontend && npm run build` e o build do frontend concluiu com sucesso, retornando apenas warnings de ESLint preexistentes; a pasta `build` foi gerada.
- Testes manuais: a rota pública `GET /dashboard-tv-compras` foi implementada e a página `/tv-compras` foi integrada ao roteamento do frontend para acesso sem login.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9ea3e29688324b7098fb09c233507)