### PR TITLE
Corrige carregamento de dados/metas no Dashboard TV Compras

### DIFF
--- a/backend/sql/dashboard_tv_compras.sql
+++ b/backend/sql/dashboard_tv_compras.sql
@@ -8,31 +8,32 @@ WITH periodos AS (
 ),
 grupos_ativos AS (
   SELECT
-    cg.codgrp,
+    TRIM(cg.codgrp) AS codgrp,
     c.nome AS comprador
   FROM scc_comprador_grupo cg
   JOIN scc_compradores c ON c.id = cg.comprador_id
-  WHERE cg.dt_fim IS NULL
+  WHERE cg.dt_inicio <= CURRENT_DATE
+    AND (cg.dt_fim IS NULL OR cg.dt_fim >= CURRENT_DATE)
 ),
 vendas AS (
   SELECT
-    v.codgrp,
+    TRIM(v.codgrp) AS codgrp,
     SUM(COALESCE(v.vlr_total_vendas_bruta, 0) - COALESCE(v.vlr_total_devolucoes, 0)) AS venda,
     SUM(COALESCE(v.vlr_total_vendas_bruta, 0) - COALESCE(v.vlr_custos_vendas, 0) - COALESCE(v.vlr_impostos_vendas, 0)) AS lb,
     SUM(CASE WHEN v.tipo IN ('FORA', 'ENCO') THEN COALESCE(v.vlr_total_vendas_bruta, 0) - COALESCE(v.vlr_total_devolucoes, 0) ELSE 0 END) AS venda_fora
   FROM vs_scc_vendas_devolucoes v
   JOIN periodos p ON true
   WHERE v.data BETWEEN p.inicio_atual AND p.fim_atual
-  GROUP BY v.codgrp
+  GROUP BY TRIM(v.codgrp)
 ),
 vendas_ano_ant AS (
   SELECT
-    v.codgrp,
+    TRIM(v.codgrp) AS codgrp,
     SUM(COALESCE(v.vlr_total_vendas_bruta, 0) - COALESCE(v.vlr_total_devolucoes, 0)) AS venda
   FROM vs_scc_vendas_devolucoes v
   JOIN periodos p ON true
   WHERE v.data BETWEEN p.inicio_ano_passado AND p.fim_ano_passado
-  GROUP BY v.codgrp
+  GROUP BY TRIM(v.codgrp)
 )
 SELECT
   ga.codgrp,
@@ -46,7 +47,7 @@ FROM grupos_ativos ga
 LEFT JOIN vendas v ON v.codgrp = ga.codgrp
 LEFT JOIN vendas_ano_ant va ON va.codgrp = ga.codgrp
 LEFT JOIN periodos p ON true
-LEFT JOIN scc_metas_compradores m ON m.codgrp = ga.codgrp
+LEFT JOIN scc_metas_compradores m ON TRIM(m.codgrp) = ga.codgrp
   AND m.mes = EXTRACT(MONTH FROM p.inicio_atual)::int
   AND m.ano = EXTRACT(YEAR FROM p.inicio_atual)::int
 ORDER BY venda_percentual_meta ASC, ga.comprador;

--- a/backend/src/services/dashboardTvComprasService.ts
+++ b/backend/src/services/dashboardTvComprasService.ts
@@ -13,31 +13,32 @@ export const getDashboardTvCompras = async () => {
     ),
     grupos_ativos AS (
       SELECT
-        cg.codgrp,
+        TRIM(cg.codgrp) AS codgrp,
         c.nome AS comprador
       FROM scc_comprador_grupo cg
       JOIN scc_compradores c ON c.id = cg.comprador_id
-      WHERE cg.dt_fim IS NULL
+      WHERE cg.dt_inicio <= CURRENT_DATE
+        AND (cg.dt_fim IS NULL OR cg.dt_fim >= CURRENT_DATE)
     ),
     vendas AS (
       SELECT
-        v.codgrp,
+        TRIM(v.codgrp) AS codgrp,
         SUM(COALESCE(v.vlr_total_vendas_bruta, 0) - COALESCE(v.vlr_total_devolucoes, 0)) AS venda,
         SUM(COALESCE(v.vlr_total_vendas_bruta, 0) - COALESCE(v.vlr_custos_vendas, 0) - COALESCE(v.vlr_impostos_vendas, 0)) AS lb,
         SUM(CASE WHEN v.tipo IN ('FORA', 'ENCO') THEN COALESCE(v.vlr_total_vendas_bruta, 0) - COALESCE(v.vlr_total_devolucoes, 0) ELSE 0 END) AS venda_fora
       FROM vs_scc_vendas_devolucoes v
       JOIN periodos p ON true
       WHERE v.data BETWEEN p.inicio_atual AND p.fim_atual
-      GROUP BY v.codgrp
+      GROUP BY TRIM(v.codgrp)
     ),
     vendas_ano_ant AS (
       SELECT
-        v.codgrp,
+        TRIM(v.codgrp) AS codgrp,
         SUM(COALESCE(v.vlr_total_vendas_bruta, 0) - COALESCE(v.vlr_total_devolucoes, 0)) AS venda
       FROM vs_scc_vendas_devolucoes v
       JOIN periodos p ON true
       WHERE v.data BETWEEN p.inicio_ano_passado AND p.fim_ano_passado
-      GROUP BY v.codgrp
+      GROUP BY TRIM(v.codgrp)
     )
     SELECT
       ga.codgrp,
@@ -54,7 +55,7 @@ export const getDashboardTvCompras = async () => {
     LEFT JOIN vendas v ON v.codgrp = ga.codgrp
     LEFT JOIN vendas_ano_ant va ON va.codgrp = ga.codgrp
     LEFT JOIN periodos p ON true
-    LEFT JOIN scc_metas_compradores m ON m.codgrp = ga.codgrp
+    LEFT JOIN scc_metas_compradores m ON TRIM(m.codgrp) = ga.codgrp
       AND m.mes = EXTRACT(MONTH FROM p.inicio_atual)::int
       AND m.ano = EXTRACT(YEAR FROM p.inicio_atual)::int
     ORDER BY venda_percentual_meta ASC, ga.comprador;


### PR DESCRIPTION
### Motivation
- O dashboard não estava trazendo compradores e metas porque o filtro de vigência em `scc_comprador_grupo` era muito restritivo e `codgrp` podia falhar no `JOIN` por espaços em branco. 
- Há preocupação com o formato da coluna `mes` em `scc_metas_compradores` (inteiro `5` versus `'05'`), então a solução deve continuar compatível com meses inteiros. 

### Description
- Ajusta a CTE `grupos_ativos` para considerar vigência por data usando `cg.dt_inicio <= CURRENT_DATE` e `cg.dt_fim IS NULL OR cg.dt_fim >= CURRENT_DATE` em vez de `dt_fim IS NULL` para incluir compradores vigentes. 
- Normaliza `codgrp` com `TRIM(...)` na seleção/agregação de vendas (`vendas`, `vendas_ano_ant`) e na junção com `scc_metas_compradores` para evitar falhas de match por espaços. 
- Atualiza tanto o arquivo de serviço `backend/src/services/dashboardTvComprasService.ts` quanto o SQL de referência `backend/sql/dashboard_tv_compras.sql` e mantém a associação de metas por `m.mes = EXTRACT(MONTH FROM ... )::int` e `m.ano = EXTRACT(YEAR FROM ... )::int` (compatível com `mes = 5`). 

### Testing
- Verifiquei o código afetado com buscas em todo o repositório usando `rg` e inspecionei ambos os arquivos alterados com `sed` to confirm changes, e estes comandos concluíram com sucesso. 
- Confirmei as alterações no diff e no status com `git status --short` e efetuei o commit das duas alterações com sucesso. 
- Não foram executados testes de integração automatizados contra o banco neste rollout; as verificações foram estáticas (inspeção/grep/edição) e concluíram sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa136a2ad083249ef9d97507ace631)