### PR TITLE
Dashboard TV Compras: nível de serviço, dias de estoque e redesign do…

### DIFF
--- a/backend/src/services/dashboardTvComprasService.ts
+++ b/backend/src/services/dashboardTvComprasService.ts
@@ -4,23 +4,19 @@ const safe = (v: unknown): number => (Number.isFinite(Number(v)) ? Number(v) : 0
 
 export const getDashboardTvCompras = async () => {
   /**
-   * REGRAS DE NEGÓCIO APLICADAS:
-   *
+   * REGRAS DE NEGÓCIO:
    * 1. Período atual  : date_trunc('month', CURRENT_DATE) → CURRENT_DATE
    * 2. Período base   : mesmo intervalo do ano anterior (dia a dia)
-   * 3. Dias faturados : COUNT(DISTINCT data) — apenas dias com movimento real
-   * 4. Meta ajustada  : meta_mensal × (dias_faturados_atual / dias_faturados_mes_base)
-   *    onde dias_mes_base = mês COMPLETO do ano passado (referência de ritmo)
-   * 5. Grupos ativos  : dt_fim IS NULL apenas
-   * 6. Metas          : JOIN por comprador_id + codgrp + mes + ano (inteiros)
-   * 7. Produtos fora  : tipo IN ('FORA','ENCO'), venda líquida
-   * 8. Sem R$         : apenas percentuais expostos
+   * 3. Dias faturados : COUNT(DISTINCT data)
+   * 4. Meta ajustada  : meta_mensal × (dias_faturados_atual / dias_mes_base)
+   * 5. Nível serviço  : % itens (produto×loja) com saldo_estoque > 0 — via vs_scc_festoques
+   * 6. Dias estoque   : valor_estoque_custo / custo_médio_diário do mês atual
+   * 7. Vs mês ant.    : mesmo n° de dias desde o início do mês (ex: mai 1-5 vs abr 1-5)
    */
 
-  const query = `
+  // ── Query 1: métricas por comprador ────────────────────────────────────────
+  const queryCompradores = `
     WITH
-
-    -- Grupos e compradores ativos (apenas registros sem data de encerramento)
     grupos_ativos AS (
       SELECT
         TRIM(cg.codgrp)   AS codgrp,
@@ -30,49 +26,34 @@ export const getDashboardTvCompras = async () => {
       JOIN scc_compradores c ON c.id = cg.comprador_id
       WHERE cg.dt_fim IS NULL
     ),
-
-    -- Dias com faturamento no periodo atual (mes corrente ate hoje)
     dias_atual AS (
-      SELECT
-        TRIM(codgrp) AS codgrp,
-        COUNT(DISTINCT data) AS qtd
+      SELECT TRIM(codgrp) AS codgrp, COUNT(DISTINCT data) AS qtd
       FROM vs_scc_vendas_devolucoes
-      WHERE data BETWEEN date_trunc('month', CURRENT_DATE)::date
-                     AND CURRENT_DATE
+      WHERE data BETWEEN date_trunc('month', CURRENT_DATE)::date AND CURRENT_DATE
       GROUP BY TRIM(codgrp)
     ),
-
-    -- Dias com faturamento no mes COMPLETO do ano passado
-    --    Usado como denominador para pro-ratear a meta mensal
     dias_mes_base AS (
-      SELECT
-        TRIM(codgrp) AS codgrp,
-        COUNT(DISTINCT data) AS qtd
+      SELECT TRIM(codgrp) AS codgrp, COUNT(DISTINCT data) AS qtd
       FROM vs_scc_vendas_devolucoes
       WHERE data BETWEEN date_trunc('month', CURRENT_DATE - interval '1 year')::date
                      AND (date_trunc('month', CURRENT_DATE - interval '1 year')
                           + interval '1 month' - interval '1 day')::date
       GROUP BY TRIM(codgrp)
     ),
-
-    -- Vendas do periodo atual
     vendas_atual AS (
       SELECT
         TRIM(codgrp) AS codgrp,
-        SUM(COALESCE(vlr_total_vendas_bruta,  0) - COALESCE(vlr_total_devolucoes, 0))              AS venda,
-        SUM(COALESCE(vlr_total_vendas_bruta,  0)
-          - COALESCE(vlr_custos_vendas,        0)
-          - COALESCE(vlr_impostos_vendas,      0))                                                  AS lb,
+        SUM(COALESCE(vlr_total_vendas_bruta, 0) - COALESCE(vlr_total_devolucoes, 0))              AS venda,
+        SUM(COALESCE(vlr_total_vendas_bruta, 0)
+          - COALESCE(vlr_custos_vendas,       0)
+          - COALESCE(vlr_impostos_vendas,     0))                                                  AS lb,
         SUM(CASE WHEN tipo IN ('FORA','ENCO')
                  THEN COALESCE(vlr_total_vendas_bruta, 0) - COALESCE(vlr_total_devolucoes, 0)
                  ELSE 0 END)                                                                        AS venda_fora
       FROM vs_scc_vendas_devolucoes
-      WHERE data BETWEEN date_trunc('month', CURRENT_DATE)::date
-                     AND CURRENT_DATE
+      WHERE data BETWEEN date_trunc('month', CURRENT_DATE)::date AND CURRENT_DATE
       GROUP BY TRIM(codgrp)
     ),
-
-    -- Vendas do mesmo periodo do ano passado (para evolucao)
     vendas_ano_passado AS (
       SELECT
         TRIM(codgrp) AS codgrp,
@@ -82,92 +63,165 @@ export const getDashboardTvCompras = async () => {
                      AND (CURRENT_DATE - interval '1 year')::date
       GROUP BY TRIM(codgrp)
     )
-
     SELECT
       ga.comprador,
       ga.codgrp,
-
-      -- Meta ajustada: meta_mensal * (dias_atual / dias_mes_base)
-      -- Se não há base histórica usa a meta cheia como fallback
       ROUND(
         CASE
           WHEN COALESCE(db.qtd, 0) = 0 THEN COALESCE(m.meta_vendas, 0)
-          ELSE COALESCE(m.meta_vendas, 0)
-               * COALESCE(da.qtd, 0)::numeric
-               / NULLIF(db.qtd, 0)
+          ELSE COALESCE(m.meta_vendas, 0) * COALESCE(da.qtd, 0)::numeric / NULLIF(db.qtd, 0)
         END,
       2) AS meta_vendas_ajustada,
-
-      -- Venda % da meta ajustada
       ROUND(
         CASE
           WHEN COALESCE(m.meta_vendas, 0) = 0 THEN 0
-          WHEN COALESCE(db.qtd, 0) = 0         THEN
+          WHEN COALESCE(db.qtd, 0) = 0 THEN
             COALESCE(va.venda, 0) / NULLIF(m.meta_vendas, 0) * 100
           ELSE
-            COALESCE(va.venda, 0) / NULLIF(
-              m.meta_vendas * COALESCE(da.qtd, 0)::numeric / db.qtd,
-            0) * 100
+            COALESCE(va.venda, 0) / NULLIF(m.meta_vendas * COALESCE(da.qtd, 0)::numeric / db.qtd, 0) * 100
         END,
       2) AS venda_percentual_meta,
-
-      -- LB % (lucro bruto sobre venda liquida)
-      ROUND(
-        COALESCE(va.lb,    0) / NULLIF(va.venda, 0) * 100,
-      2) AS lb_percentual,
-
-      -- Meta LB % (percentual-alvo informado no cadastro)
+      ROUND(COALESCE(va.lb, 0) / NULLIF(va.venda, 0) * 100, 2) AS lb_percentual,
       COALESCE(m.meta_lb, 0) AS meta_lb,
-
-      -- Evolucao vs mesmo periodo do ano passado
-      ROUND(
-        (COALESCE(va.venda, 0) / NULLIF(vap.venda, 0) - 1) * 100,
-      2) AS evolucao_percentual,
-
-      -- Produtos fora % da meta ajustada
+      ROUND((COALESCE(va.venda, 0) / NULLIF(vap.venda, 0) - 1) * 100, 2) AS evolucao_percentual,
       ROUND(
         CASE
           WHEN COALESCE(m.meta_produtos_fora, 0) = 0 THEN 0
-          WHEN COALESCE(db.qtd, 0) = 0               THEN
+          WHEN COALESCE(db.qtd, 0) = 0 THEN
             COALESCE(va.venda_fora, 0) / NULLIF(m.meta_produtos_fora, 0) * 100
           ELSE
             COALESCE(va.venda_fora, 0) / NULLIF(
-              m.meta_produtos_fora * COALESCE(da.qtd, 0)::numeric / db.qtd,
-            0) * 100
+              m.meta_produtos_fora * COALESCE(da.qtd, 0)::numeric / db.qtd, 0) * 100
         END,
       2) AS produtos_fora_percentual
-
     FROM grupos_ativos ga
-
-    -- Vendas do período atual
     LEFT JOIN vendas_atual       va  ON va.codgrp  = ga.codgrp
-
-    -- Vendas do mesmo período do ano passado
     LEFT JOIN vendas_ano_passado vap ON vap.codgrp = ga.codgrp
-
-    -- Dias faturados no período atual
     LEFT JOIN dias_atual         da  ON da.codgrp  = ga.codgrp
-
-    -- Dias faturados no mês completo do ano passado (base para pro-rata da meta)
     LEFT JOIN dias_mes_base      db  ON db.codgrp  = ga.codgrp
-
-    -- Metas: join por comprador_id + codgrp + mês/ano inteiros (sem TO_CHAR)
     LEFT JOIN scc_metas_compradores m
       ON  m.comprador_id = ga.comprador_id
       AND TRIM(m.codgrp) = ga.codgrp
-      AND m.mes          = EXTRACT(MONTH FROM CURRENT_DATE)::int
-      AND m.ano          = EXTRACT(YEAR  FROM CURRENT_DATE)::int
-
+      AND m.mes = EXTRACT(MONTH FROM CURRENT_DATE)::int
+      AND m.ano = EXTRACT(YEAR  FROM CURRENT_DATE)::int
     ORDER BY venda_percentual_meta ASC, ga.comprador
   `
 
-  const result = await pool.query(query)
+  // ── Query 2: métricas globais (nível de serviço, dias de estoque, totais) ──
+  const queryGlobal = `
+    WITH
+    -- Vendas período atual
+    va AS (
+      SELECT
+        COALESCE(SUM(COALESCE(vlr_total_vendas_bruta, 0) - COALESCE(vlr_total_devolucoes, 0)), 0)   AS venda,
+        COALESCE(SUM(COALESCE(vlr_total_vendas_bruta, 0)
+                   - COALESCE(vlr_custos_vendas,       0)
+                   - COALESCE(vlr_impostos_vendas,     0)), 0)                                       AS lb,
+        COALESCE(SUM(CASE WHEN tipo IN ('FORA','ENCO')
+                     THEN COALESCE(vlr_total_vendas_bruta, 0) - COALESCE(vlr_total_devolucoes, 0)
+                     ELSE 0 END), 0)                                                                 AS venda_fora,
+        COALESCE(SUM(COALESCE(vlr_custos_vendas, 0)), 0)                                             AS custo_total,
+        COUNT(DISTINCT data)                                                                         AS dias_com_venda
+      FROM vs_scc_vendas_devolucoes
+      WHERE data BETWEEN date_trunc('month', CURRENT_DATE)::date AND CURRENT_DATE
+    ),
+    -- Vendas mês anterior (mesmo n° de dias desde o início do mês)
+    vant AS (
+      SELECT
+        COALESCE(SUM(COALESCE(vlr_total_vendas_bruta, 0) - COALESCE(vlr_total_devolucoes, 0)), 0)   AS venda,
+        COALESCE(SUM(COALESCE(vlr_total_vendas_bruta, 0)
+                   - COALESCE(vlr_custos_vendas,       0)
+                   - COALESCE(vlr_impostos_vendas,     0)), 0)                                       AS lb,
+        COALESCE(SUM(CASE WHEN tipo IN ('FORA','ENCO')
+                     THEN COALESCE(vlr_total_vendas_bruta, 0) - COALESCE(vlr_total_devolucoes, 0)
+                     ELSE 0 END), 0)                                                                 AS venda_fora
+      FROM vs_scc_vendas_devolucoes
+      WHERE data BETWEEN
+        date_trunc('month', CURRENT_DATE - interval '1 month')::date
+        AND (CURRENT_DATE - interval '1 month')::date
+    ),
+    -- Meta total dos compradores ativos no mês atual
+    metas AS (
+      SELECT
+        COALESCE(SUM(m.meta_vendas),       0) AS meta_vendas,
+        COALESCE(SUM(m.meta_produtos_fora), 0) AS meta_produtos_fora,
+        COALESCE(AVG(m.meta_lb),           0) AS meta_lb_media
+      FROM scc_comprador_grupo cg
+      JOIN scc_compradores c ON c.id = cg.comprador_id
+      JOIN scc_metas_compradores m
+        ON  m.comprador_id = cg.comprador_id
+        AND TRIM(m.codgrp) = TRIM(cg.codgrp)
+        AND m.mes = EXTRACT(MONTH FROM CURRENT_DATE)::int
+        AND m.ano = EXTRACT(YEAR  FROM CURRENT_DATE)::int
+      WHERE cg.dt_fim IS NULL
+    ),
+    -- Nível de serviço: % de itens produto×loja com saldo_estoque > 0
+    ns AS (
+      SELECT
+        ROUND(
+          COUNT(CASE WHEN saldo_estoque > 0 THEN 1 END)::numeric /
+          NULLIF(COUNT(*), 0) * 100,
+        1) AS nivel_servico
+      FROM vs_scc_festoques
+    ),
+    -- Valor do estoque a custo médio
+    est AS (
+      SELECT
+        COALESCE(SUM(GREATEST(saldo_estoque, 0) *
+                     COALESCE(NULLIF(prc_custo_medio, 0), prc_custo, 0)), 0) AS valor_estoque
+      FROM vs_scc_festoques
+    )
+    SELECT
+      ns.nivel_servico,
+      -- Dias de estoque = valor estoque / custo médio diário
+      ROUND(
+        est.valor_estoque /
+        NULLIF(va.custo_total::numeric / NULLIF(va.dias_com_venda, 0), 0),
+      0) AS dias_estoque,
+      va.venda         AS vendas_valor,
+      va.lb            AS lb_valor,
+      va.venda_fora    AS produtos_fora_valor,
+      vant.venda       AS vendas_ant_valor,
+      vant.lb          AS lb_ant_valor,
+      vant.venda_fora  AS produtos_fora_ant_valor,
+      ROUND(va.lb   / NULLIF(va.venda,   0) * 100, 1) AS lb_pct,
+      ROUND(vant.lb / NULLIF(vant.venda, 0) * 100, 1) AS lb_ant_pct,
+      metas.meta_vendas,
+      metas.meta_produtos_fora,
+      metas.meta_lb_media
+    FROM va, vant, metas, ns, est
+  `
 
-  const compradores = result.rows.map((row) => {
-    const vendaMeta = safe(row.venda_percentual_meta)
-    const lbPct = safe(row.lb_percentual)
-    const metaLb = safe(row.meta_lb)
-    const evolucao = safe(row.evolucao_percentual)
+  // ── Query 3: série diária para sparklines ──────────────────────────────────
+  const querySeries = `
+    SELECT
+      data::date AS dia,
+      SUM(COALESCE(vlr_total_vendas_bruta, 0) - COALESCE(vlr_total_devolucoes, 0))           AS venda,
+      SUM(COALESCE(vlr_total_vendas_bruta, 0)
+        - COALESCE(vlr_custos_vendas,       0)
+        - COALESCE(vlr_impostos_vendas,     0))                                               AS lb,
+      SUM(CASE WHEN tipo IN ('FORA','ENCO')
+               THEN COALESCE(vlr_total_vendas_bruta, 0) - COALESCE(vlr_total_devolucoes, 0)
+               ELSE 0 END)                                                                    AS produtos_fora
+    FROM vs_scc_vendas_devolucoes
+    WHERE data >= date_trunc('month', CURRENT_DATE)::date
+      AND data <= CURRENT_DATE
+    GROUP BY data::date
+    ORDER BY data::date
+  `
+
+  const [r1, r2, r3] = await Promise.all([
+    pool.query(queryCompradores),
+    pool.query(queryGlobal),
+    pool.query(querySeries),
+  ])
+
+  // ── Compradores ────────────────────────────────────────────────────────────
+  const compradores = r1.rows.map((row) => {
+    const vendaMeta    = safe(row.venda_percentual_meta)
+    const lbPct        = safe(row.lb_percentual)
+    const metaLb       = safe(row.meta_lb)
+    const evolucao     = safe(row.evolucao_percentual)
     const produtosForaPct = safe(row.produtos_fora_percentual)
 
     const status =
@@ -187,20 +241,77 @@ export const getDashboardTvCompras = async () => {
     }
   })
 
-  // KPIs: média ponderada simples entre todos os compradores
+  // ── Global metrics ─────────────────────────────────────────────────────────
+  const gm = r2.rows[0] ?? {}
+
+  const vendasValor      = safe(gm.vendas_valor)
+  const vendasAnt        = safe(gm.vendas_ant_valor)
+  const lbPct            = safe(gm.lb_pct)
+  const lbAntPct         = safe(gm.lb_ant_pct)
+  const produtosForaValor = safe(gm.produtos_fora_valor)
+  const produtosForaAnt  = safe(gm.produtos_fora_ant_valor)
+
+  // ── Série diária ───────────────────────────────────────────────────────────
+  const series = r3.rows.map((row) => ({
+    dia: row.dia,
+    venda: safe(row.venda),
+    lb: safe(row.lb),
+    produtosFora: safe(row.produtos_fora),
+  }))
+
+  // ── KPIs consolidados ──────────────────────────────────────────────────────
   const n = compradores.length || 1
-  const media = (arr: number[]) => arr.reduce((s, v) => s + v, 0) / n
+  const avg = (arr: number[]) => arr.reduce((s, v) => s + v, 0) / n
 
   const kpis = {
-    vendasAtingimento: Number(media(compradores.map((c) => c.vendaPercentualMeta)).toFixed(2)),
-    lbRealizado: Number(media(compradores.map((c) => c.lbPercentual)).toFixed(2)),
-    lbMeta: Number(media(compradores.map((c) => c.metaLb)).toFixed(2)),
-    evolucao: Number(media(compradores.map((c) => c.evolucaoPercentual)).toFixed(2)),
-    nivelServico: null,
-    diasEstoque: null,
-    produtosFora: Number(media(compradores.map((c) => c.produtosForaPercentual)).toFixed(2)),
+    // VENDAS (R$)
+    vendasValor,
+    metaVendas:           safe(gm.meta_vendas),
+    vendasVsMesAnterior:  vendasAnt > 0
+      ? Number(((vendasValor / vendasAnt - 1) * 100).toFixed(1))
+      : null as number | null,
+
+    // LB (%)
+    lbPercentual: lbPct,
+    metaLb:       safe(gm.meta_lb_media),
+    lbVsMesAnterior: lbAntPct > 0
+      ? Number((lbPct - lbAntPct).toFixed(1))
+      : null as number | null,
+
+    // NÍVEL DE SERVIÇO (%)
+    nivelServico:              safe(gm.nivel_servico),
+    nivelServicoMeta:          98,
+    nivelServicoVsMesAnterior: null as number | null,
+
+    // EVOLUÇÃO (%)
+    evolucao:               Number(avg(compradores.map((c) => c.evolucaoPercentual)).toFixed(1)),
+    evolucaoMeta:           100,
+    evolucaoVsMesAnterior:  null as number | null,
+
+    // DIAS DE ESTOQUE
+    diasEstoque:              safe(gm.dias_estoque),
+    diasEstoqueMeta:          45,
+    diasEstoqueVsMesAnterior: null as number | null,
+
+    // PRODUTOS FORA
+    produtosForaValor,
+    metaProdutosFora:          safe(gm.meta_produtos_fora),
+    produtosForaVsMesAnterior: produtosForaAnt > 0
+      ? Number(((produtosForaValor / produtosForaAnt - 1) * 100).toFixed(1))
+      : null as number | null,
+
+    // Legacy (mantido para compatibilidade)
+    vendasAtingimento: Number(avg(compradores.map((c) => c.vendaPercentualMeta)).toFixed(2)),
+    lbRealizado:       lbPct,
+    evolucaoLegacy:    Number(avg(compradores.map((c) => c.evolucaoPercentual)).toFixed(2)),
+    nivelServico2:     null,
+    diasEstoque2:      null,
+    produtosFora:      safe(gm.meta_produtos_fora) > 0
+      ? Number((produtosForaValor / safe(gm.meta_produtos_fora) * 100).toFixed(2))
+      : 0,
   }
 
+  // ── Alertas ────────────────────────────────────────────────────────────────
   const alertas: string[] = []
   compradores.forEach((c) => {
     if (c.lbPercentual > 0 && c.lbPercentual < c.metaLb)
@@ -216,10 +327,11 @@ export const getDashboardTvCompras = async () => {
   return {
     kpis,
     compradores,
+    series,
     graficos: {
       evolucaoVendas: compradores.map((c) => ({ label: c.comprador, valor: c.vendaPercentualMeta })),
-      evolucaoLb: compradores.map((c) => ({ label: c.comprador, valor: c.lbPercentual })),
-      produtosFora: compradores.map((c) => ({ label: c.comprador, valor: c.produtosForaPercentual })),
+      evolucaoLb:     compradores.map((c) => ({ label: c.comprador, valor: c.lbPercentual })),
+      produtosFora:   compradores.map((c) => ({ label: c.comprador, valor: c.produtosForaPercentual })),
     },
     alertas,
   }

--- a/frontend/src/pages/TvCompras.tsx
+++ b/frontend/src/pages/TvCompras.tsx
@@ -1,40 +1,266 @@
 import { useEffect, useState } from "react"
 import {
-  Alert,
   Box,
   Button,
+  CircularProgress,
+  Grid,
+  Stack,
+  Typography,
   Card,
   CardContent,
   Chip,
-  CircularProgress,
-  Grid,
-  LinearProgress,
-  Stack,
   Table,
   TableBody,
   TableCell,
   TableHead,
   TableRow,
-  Typography,
+  LinearProgress,
+  Alert,
 } from "@mui/material"
-import { Refresh as RefreshIcon } from "@mui/icons-material"
+import {
+  AttachMoney,
+  BarChart as BarChartIcon,
+  LocalShipping,
+  TrackChanges,
+  Inventory2,
+  Warning,
+  Refresh as RefreshIcon,
+  CalendarToday,
+  AccessTime,
+} from "@mui/icons-material"
 import { getDashboardTvCompras } from "../services/dashboardTvComprasService"
+
+// ── Utilitários ──────────────────────────────────────────────────────────────
+
+const safe = (v: unknown): number => (Number.isFinite(Number(v)) ? Number(v) : 0)
+
+const fmtMoeda = (v: number) =>
+  new Intl.NumberFormat("pt-BR", { minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(v)
+
+const fmtPct = (v: number, casas = 1) => `${v.toFixed(casas).replace(".", ",")}%`
+
+// ── Sparkline SVG simples ────────────────────────────────────────────────────
+
+function Sparkline({
+  data,
+  color,
+  width = 80,
+  height = 40,
+}: {
+  data: number[]
+  color: string
+  width?: number
+  height?: number
+}) {
+  if (!data || data.length < 2) return null
+  const min = Math.min(...data)
+  const max = Math.max(...data)
+  const range = max - min || 1
+  const pad = height * 0.1
+  const pts = data
+    .map((v, i) => {
+      const x = (i / (data.length - 1)) * width
+      const y = height - pad - ((v - min) / range) * (height - 2 * pad)
+      return `${x.toFixed(1)},${y.toFixed(1)}`
+    })
+    .join(" ")
+  return (
+    <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`} style={{ flexShrink: 0 }}>
+      <polyline points={pts} fill="none" stroke={color} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+function BarSparkline({
+  data,
+  color,
+  width = 80,
+  height = 40,
+}: {
+  data: number[]
+  color: string
+  width?: number
+  height?: number
+}) {
+  if (!data || data.length === 0) return null
+  const max = Math.max(...data) || 1
+  const barW = Math.max(1, Math.floor(width / data.length) - 2)
+  return (
+    <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`} style={{ flexShrink: 0 }}>
+      {data.map((v, i) => {
+        const bh = Math.max(2, (v / max) * (height * 0.85))
+        return (
+          <rect
+            key={i}
+            x={i * (barW + 2)}
+            y={height - bh}
+            width={barW}
+            height={bh}
+            fill={color}
+            opacity={i === data.length - 1 ? 1 : 0.55}
+            rx="1"
+          />
+        )
+      })}
+    </svg>
+  )
+}
+
+// ── Card KPI ─────────────────────────────────────────────────────────────────
+
+interface KpiCardProps {
+  title: string
+  icon: React.ReactNode
+  value: string
+  meta: string
+  trend: number | null
+  trendSuffix: string
+  /** true = subir é bom (verde), false = subir é ruim (vermelho) */
+  trendUpGood: boolean
+  sparkData?: number[]
+  sparkType?: "line" | "bar"
+  color: string
+  /** true quando o valor está fora da meta — realça borda */
+  alertMode?: boolean
+}
+
+function KpiCard({
+  title,
+  icon,
+  value,
+  meta,
+  trend,
+  trendSuffix,
+  trendUpGood,
+  sparkData,
+  sparkType = "line",
+  color,
+  alertMode = false,
+}: KpiCardProps) {
+  const trendPositive = trend === null ? null : trendUpGood ? trend >= 0 : trend <= 0
+  const trendColor = trendPositive === null ? "#9CA3AF" : trendPositive ? "#22C55E" : "#EF4444"
+  const trendArrow = trend === null ? "" : trend >= 0 ? "↑" : "↓"
+  const trendStr =
+    trend === null
+      ? null
+      : `${trendArrow} ${trend >= 0 ? "+" : ""}${trend.toFixed(1).replace(".", ",")}${trendSuffix}`
+
+  return (
+    <Card
+      sx={{
+        background: "linear-gradient(135deg, #0D1117 0%, #0F1923 100%)",
+        border: `1px solid ${alertMode ? color : color + "44"}`,
+        borderTop: `2px solid ${color}`,
+        borderRadius: 2,
+        height: "100%",
+        position: "relative",
+        overflow: "hidden",
+        boxShadow: alertMode ? `0 0 12px ${color}55` : "none",
+      }}
+    >
+      <CardContent sx={{ p: "12px !important" }}>
+        {/* Título */}
+        <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", mb: 0.5 }}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+            <Box
+              sx={{
+                width: 28,
+                height: 28,
+                borderRadius: "50%",
+                border: `1.5px solid ${color}`,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                color: color,
+                "& svg": { fontSize: "0.9rem" },
+              }}
+            >
+              {icon}
+            </Box>
+            <Typography
+              sx={{
+                color: color,
+                fontWeight: 700,
+                fontSize: "0.6rem",
+                letterSpacing: "0.08em",
+                textTransform: "uppercase",
+                lineHeight: 1.2,
+              }}
+            >
+              {title}
+            </Typography>
+          </Box>
+          {/* Sparkline */}
+          {sparkData && sparkData.length > 1 && (
+            <Box sx={{ opacity: 0.85 }}>
+              {sparkType === "line" ? (
+                <Sparkline data={sparkData} color={color} />
+              ) : (
+                <BarSparkline data={sparkData} color={color} />
+              )}
+            </Box>
+          )}
+        </Box>
+
+        {/* Valor principal */}
+        <Typography
+          sx={{
+            fontSize: "1.65rem",
+            fontWeight: 800,
+            color: "#F9FAFB",
+            lineHeight: 1,
+            mb: 0.4,
+            fontVariantNumeric: "tabular-nums",
+          }}
+        >
+          {value}
+        </Typography>
+
+        {/* Meta */}
+        <Typography sx={{ fontSize: "0.7rem", color: "#6B7280", mb: 0.5 }}>
+          Meta: {meta}
+        </Typography>
+
+        {/* Tendência vs mês anterior */}
+        {trendStr && (
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.4 }}>
+            <Typography sx={{ fontSize: "0.72rem", color: trendColor, fontWeight: 600 }}>
+              {trendStr}
+            </Typography>
+            <Typography sx={{ fontSize: "0.65rem", color: "#4B5563" }}>
+              vs mês anterior
+            </Typography>
+          </Box>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+// ── Status da tabela ─────────────────────────────────────────────────────────
 
 const statusColor = (v: number) => (v >= 100 ? "success" : v >= 95 ? "warning" : "error")
 
-// Garante que qualquer valor retornado pelo backend seja um número finito
-const safe = (v: unknown): number => (Number.isFinite(Number(v)) ? Number(v) : 0)
+// ── Componente principal ─────────────────────────────────────────────────────
 
 export default function TvCompras() {
   const [data, setData] = useState<any>({
     kpis: {},
     compradores: [],
+    series: [],
     graficos: { evolucaoVendas: [], evolucaoLb: [] },
     alertas: [],
   })
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [lastUpdate, setLastUpdate] = useState<Date | null>(null)
+  const [now, setNow] = useState(new Date())
+
+  // Relógio em tempo real
+  useEffect(() => {
+    const tick = setInterval(() => setNow(new Date()), 1000)
+    return () => clearInterval(tick)
+  }, [])
 
   const fetchDados = async () => {
     setLoading(true)
@@ -47,10 +273,10 @@ export default function TvCompras() {
       console.error("Erro ao buscar dashboard TV compras", err)
       const msg =
         err?.code === "ERR_NETWORK" || err?.response?.status === 0
-          ? "Não foi possível conectar ao servidor. Verifique se o backend está rodando."
+          ? "Não foi possível conectar ao servidor."
           : err?.response?.data?.message
           ? `Erro do servidor: ${err.response.data.message}`
-          : "Erro ao carregar dados. Tentativa automática em 30 minutos."
+          : "Erro ao carregar dados."
       setError(msg)
     } finally {
       setLoading(false)
@@ -59,11 +285,11 @@ export default function TvCompras() {
 
   useEffect(() => {
     fetchDados()
-    const timer = setInterval(fetchDados, 1800000) // atualiza a cada 30 min
+    const timer = setInterval(fetchDados, 1800000)
     return () => clearInterval(timer)
   }, [])
 
-  // Primeira carga — ainda sem dados: exibe tela de loading ou erro
+  // Tela de carga inicial
   if (loading && !lastUpdate) {
     return (
       <Box display="flex" justifyContent="center" alignItems="center" height="100vh" bgcolor="#0b0f14">
@@ -81,12 +307,8 @@ export default function TvCompras() {
         <Stack alignItems="center" spacing={3} sx={{ maxWidth: 500, p: 4, textAlign: "center" }}>
           <Typography variant="h5" color="#EF4444" fontWeight={700}>Falha ao carregar</Typography>
           <Typography color="#94A3B8">{error}</Typography>
-          <Button
-            variant="outlined"
-            startIcon={<RefreshIcon />}
-            onClick={fetchDados}
-            sx={{ color: "#EF9A9A", borderColor: "#EF9A9A" }}
-          >
+          <Button variant="outlined" startIcon={<RefreshIcon />} onClick={fetchDados}
+            sx={{ color: "#EF9A9A", borderColor: "#EF9A9A" }}>
             Tentar novamente
           </Button>
         </Stack>
@@ -94,147 +316,295 @@ export default function TvCompras() {
     )
   }
 
-  const kpis = [
-    { label: "Vendas (% Meta)", value: safe(data.kpis?.vendasAtingimento) },
-    { label: "LB (% Realizado)", value: safe(data.kpis?.lbRealizado) },
-    { label: "Evolução (%)", value: safe(data.kpis?.evolucao) },
-    { label: "Nível de Serviço", value: null },
-    { label: "Dias de Estoque", value: null },
-    { label: "Produtos Fora (% Meta)", value: safe(data.kpis?.produtosFora) },
+  // ── Dados extraídos ──────────────────────────────────────────────────────
+  const kpis = data.kpis ?? {}
+  const series: { dia: string; venda: number; lb: number; produtosFora: number }[] = data.series ?? []
+
+  const sparkVendas       = series.map((s) => s.venda)
+  const sparkLbPct        = series.map((s) => (s.venda > 0 ? (s.lb / s.venda) * 100 : 0))
+  const sparkProdutosFora = series.map((s) => s.produtosFora)
+
+  const mesAtual = now.toLocaleDateString("pt-BR", { month: "long", year: "numeric" }).toUpperCase()
+  const minUpdate = lastUpdate
+    ? Math.round((now.getTime() - lastUpdate.getTime()) / 60000)
+    : null
+
+  // ── Definição dos 6 cards ────────────────────────────────────────────────
+
+  const cards: KpiCardProps[] = [
+    {
+      title: "VENDAS (R$)",
+      icon: <AttachMoney />,
+      value: `${fmtMoeda(safe(kpis.vendasValor))}`,
+      meta: fmtMoeda(safe(kpis.metaVendas)),
+      trend: kpis.vendasVsMesAnterior ?? null,
+      trendSuffix: "%",
+      trendUpGood: true,
+      sparkData: sparkVendas,
+      sparkType: "line",
+      color: "#3B82F6",
+      alertMode: safe(kpis.vendasValor) < safe(kpis.metaVendas) * 0.9,
+    },
+    {
+      title: "LB (%)",
+      icon: <BarChartIcon />,
+      value: fmtPct(safe(kpis.lbPercentual)),
+      meta: fmtPct(safe(kpis.metaLb)),
+      trend: kpis.lbVsMesAnterior ?? null,
+      trendSuffix: " p.p.",
+      trendUpGood: true,
+      sparkData: sparkLbPct,
+      sparkType: "line",
+      color: "#22C55E",
+      alertMode: safe(kpis.lbPercentual) > 0 && safe(kpis.lbPercentual) < safe(kpis.metaLb),
+    },
+    {
+      title: "NÍVEL DE SERVIÇO (%)",
+      icon: <LocalShipping />,
+      value: fmtPct(safe(kpis.nivelServico)),
+      meta: fmtPct(safe(kpis.nivelServicoMeta) || 98),
+      trend: kpis.nivelServicoVsMesAnterior ?? null,
+      trendSuffix: " p.p.",
+      trendUpGood: true,
+      color: "#F97316",
+      alertMode: safe(kpis.nivelServico) > 0 && safe(kpis.nivelServico) < (safe(kpis.nivelServicoMeta) || 98),
+    },
+    {
+      title: "EVOLUÇÃO (%)",
+      icon: <TrackChanges />,
+      value: fmtPct(safe(kpis.evolucao), 0),
+      meta: fmtPct(safe(kpis.evolucaoMeta) || 100, 0),
+      trend: kpis.evolucaoVsMesAnterior ?? null,
+      trendSuffix: "%",
+      trendUpGood: true,
+      color: "#A855F7",
+      alertMode: safe(kpis.evolucao) < (safe(kpis.evolucaoMeta) || 100),
+    },
+    {
+      title: "DIAS DE ESTOQUE",
+      icon: <Inventory2 />,
+      value: `${Math.round(safe(kpis.diasEstoque))} dias`,
+      meta: `${safe(kpis.diasEstoqueMeta) || 45} dias`,
+      trend: kpis.diasEstoqueVsMesAnterior ?? null,
+      trendSuffix: " dias",
+      trendUpGood: false,
+      sparkData: sparkVendas.length > 0 ? sparkVendas.map((_, i) => i + 1) : [],
+      sparkType: "bar",
+      color: "#60A5FA",
+      alertMode: safe(kpis.diasEstoque) > (safe(kpis.diasEstoqueMeta) || 45) * 1.1,
+    },
+    {
+      title: "PRODUTOS FORA",
+      icon: <Warning />,
+      value: `R$ ${fmtMoeda(safe(kpis.produtosForaValor))}`,
+      meta: fmtMoeda(safe(kpis.metaProdutosFora)),
+      trend: kpis.produtosForaVsMesAnterior ?? null,
+      trendSuffix: "%",
+      trendUpGood: false,
+      sparkData: sparkProdutosFora,
+      sparkType: "bar",
+      color: "#EF4444",
+      alertMode: safe(kpis.produtosForaValor) > safe(kpis.metaProdutosFora) * 1.1,
+    },
   ]
 
   return (
-    <Box sx={{ minHeight: "100vh", background: "#050816", color: "#fff", p: 3 }}>
+    <Box sx={{ minHeight: "100vh", background: "#050816", color: "#fff", p: "12px 16px" }}>
 
-      {/* Cabeçalho */}
-      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 2 }}>
-        <Typography variant="h3" fontWeight={700}>Dashboard TV Compras</Typography>
-        <Stack alignItems="flex-end" spacing={0.5}>
-          {loading && <CircularProgress size={14} sx={{ color: "#94A3B8" }} />}
-          {error && <Typography variant="caption" color="#F87171">{error}</Typography>}
-          {lastUpdate && (
-            <Typography variant="caption" color="#6B7280">
-              Atualizado: {lastUpdate.toLocaleTimeString("pt-BR")}
+      {/* ── Cabeçalho ── */}
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          mb: 1.5,
+          pb: 1,
+          borderBottom: "1px solid #1E293B",
+        }}
+      >
+        {/* Esquerda: título */}
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+          <Box
+            sx={{
+              width: 44,
+              height: 44,
+              borderRadius: "50%",
+              background: "linear-gradient(135deg, #1E3A5F, #3B82F6)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <AttachMoney sx={{ color: "#fff", fontSize: "1.3rem" }} />
+          </Box>
+          <Box>
+            <Typography sx={{ fontSize: "1.3rem", fontWeight: 800, letterSpacing: "0.04em", lineHeight: 1 }}>
+              DASHBOARD COMPRAS
             </Typography>
+            <Typography sx={{ fontSize: "0.65rem", color: "#64748B", letterSpacing: "0.08em" }}>
+              VISÃO GERAL DE DESEMPENHO — {mesAtual}
+            </Typography>
+          </Box>
+        </Box>
+
+        {/* Centro: data e hora */}
+        <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+            <CalendarToday sx={{ color: "#64748B", fontSize: "0.85rem" }} />
+            <Typography sx={{ color: "#CBD5E1", fontSize: "0.85rem" }}>
+              {now.toLocaleDateString("pt-BR")}
+            </Typography>
+          </Box>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+            <AccessTime sx={{ color: "#64748B", fontSize: "0.85rem" }} />
+            <Typography sx={{ color: "#CBD5E1", fontSize: "0.85rem", fontVariantNumeric: "tabular-nums" }}>
+              {now.toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" })}
+            </Typography>
+          </Box>
+        </Box>
+
+        {/* Direita: atualização */}
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          {error && (
+            <Typography sx={{ fontSize: "0.7rem", color: "#F87171" }}>{error}</Typography>
           )}
-        </Stack>
+          <Typography sx={{ fontSize: "0.72rem", color: "#4B5563" }}>
+            {loading
+              ? "Atualizando..."
+              : minUpdate !== null
+              ? minUpdate === 0
+                ? "Atualizado agora"
+                : `Atualizado há ${minUpdate} min`
+              : ""}
+          </Typography>
+          <Box
+            onClick={fetchDados}
+            sx={{
+              cursor: "pointer",
+              color: loading ? "#64748B" : "#3B82F6",
+              display: "flex",
+              alignItems: "center",
+              "&:hover": { color: "#60A5FA" },
+            }}
+          >
+            <RefreshIcon sx={{ fontSize: "1rem" }} />
+          </Box>
+        </Box>
       </Box>
 
-      {/* KPIs */}
-      <Grid container spacing={2} mb={2}>
-        {kpis.map((kpi) => (
-          <Grid item xs={12} md={4} lg={2} key={kpi.label}>
-            <Card sx={{ background: "#111827", borderRadius: 3 }}>
-              <CardContent>
-                <Typography variant="subtitle2" color="#9CA3AF">{kpi.label}</Typography>
-                <Typography variant="h4" fontWeight={800}>
-                  {kpi.value === null ? "--" : `${safe(kpi.value).toFixed(2)}%`}
-                </Typography>
-              </CardContent>
-            </Card>
+      {/* ── 6 Cards KPI ── */}
+      <Grid container spacing={1.5} mb={1.5}>
+        {cards.map((card) => (
+          <Grid item xs={12} sm={6} md={4} lg={2} key={card.title}>
+            <KpiCard {...card} />
           </Grid>
         ))}
       </Grid>
 
-      {/* Gráficos de evolução */}
-      <Grid container spacing={2} mb={2}>
-        <Grid item xs={12} md={6}>
-          <Card sx={{ background: "#111827", p: 2, borderRadius: 3 }}>
-            <Typography variant="h6" mb={1}>Evolução de Vendas (%)</Typography>
-            <Stack spacing={1}>
-              {data.graficos?.evolucaoVendas?.length ? (
-                data.graficos.evolucaoVendas.map((item: any) => (
-                  <Box key={item.label}>
-                    <Typography variant="body2">{item.label} — {safe(item.valor).toFixed(1)}%</Typography>
-                    <LinearProgress
-                      variant="determinate"
-                      value={Math.max(0, Math.min(100, safe(item.valor)))}
-                      color={statusColor(safe(item.valor))}
-                    />
-                  </Box>
-                ))
-              ) : (
-                <Typography variant="body2" color="#6B7280">Sem dados de evolução para o período.</Typography>
-              )}
-            </Stack>
-          </Card>
-        </Grid>
-        <Grid item xs={12} md={6}>
-          <Card sx={{ background: "#111827", p: 2, borderRadius: 3 }}>
-            <Typography variant="h6" mb={1}>Evolução de LB (%)</Typography>
-            <Stack spacing={1}>
-              {data.graficos?.evolucaoLb?.length ? (
-                data.graficos.evolucaoLb.map((item: any) => (
-                  <Box key={item.label}>
-                    <Typography variant="body2">{item.label} — {safe(item.valor).toFixed(1)}%</Typography>
-                    <LinearProgress
-                      variant="determinate"
-                      value={Math.max(0, Math.min(100, safe(item.valor)))}
-                      color={statusColor(safe(item.valor))}
-                    />
-                  </Box>
-                ))
-              ) : (
-                <Typography variant="body2" color="#6B7280">Sem dados de evolução para o período.</Typography>
-              )}
-            </Stack>
-          </Card>
-        </Grid>
-      </Grid>
-
-      {/* Tabela de compradores */}
-      <Card sx={{ background: "#111827", borderRadius: 3, mb: 2 }}>
-        <CardContent>
-          <Typography variant="h6" mb={1}>Performance por Comprador</Typography>
+      {/* ── Tabela por comprador ── */}
+      <Card sx={{ background: "#0D1117", border: "1px solid #1E293B", borderRadius: 2, mb: 1.5 }}>
+        <CardContent sx={{ p: "12px !important" }}>
+          <Typography sx={{ fontWeight: 700, fontSize: "0.85rem", mb: 1, color: "#94A3B8", textTransform: "uppercase", letterSpacing: "0.06em" }}>
+            Performance por Comprador
+          </Typography>
           {data.compradores?.length ? (
             <Table size="small">
               <TableHead>
-                <TableRow>
-                  <TableCell sx={{ color: "#fff" }}>Comprador</TableCell>
-                  <TableCell sx={{ color: "#fff" }}>Grupo</TableCell>
-                  <TableCell sx={{ color: "#fff" }}>Venda (% Meta)</TableCell>
-                  <TableCell sx={{ color: "#fff" }}>LB (%)</TableCell>
-                  <TableCell sx={{ color: "#fff" }}>Meta LB (%)</TableCell>
-                  <TableCell sx={{ color: "#fff" }}>Evolução (%)</TableCell>
-                  <TableCell sx={{ color: "#fff" }}>Produtos Fora (% Meta)</TableCell>
-                  <TableCell sx={{ color: "#fff" }}>Status</TableCell>
+                <TableRow sx={{ "& th": { borderBottom: "1px solid #1E293B", py: 0.5 } }}>
+                  {["Comprador", "Grupo", "Venda (% Meta)", "LB (%)", "Meta LB", "Evolução", "Prod. Fora (%)", "Status"].map((h) => (
+                    <TableCell key={h} sx={{ color: "#64748B", fontSize: "0.7rem", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.04em" }}>
+                      {h}
+                    </TableCell>
+                  ))}
                 </TableRow>
               </TableHead>
               <TableBody>
                 {data.compradores.map((c: any) => (
-                  <TableRow key={`${c.grupo}-${c.comprador}`}>
-                    <TableCell sx={{ color: "#E5E7EB" }}>{c.comprador}</TableCell>
-                    <TableCell sx={{ color: "#E5E7EB" }}>{c.grupo}</TableCell>
-                    <TableCell sx={{ color: "#E5E7EB" }}>{safe(c.vendaPercentualMeta).toFixed(2)}%</TableCell>
-                    <TableCell sx={{ color: "#E5E7EB" }}>{safe(c.lbPercentual).toFixed(2)}%</TableCell>
-                    <TableCell sx={{ color: "#E5E7EB" }}>{safe(c.metaLb).toFixed(2)}%</TableCell>
-                    <TableCell sx={{ color: "#E5E7EB" }}>{safe(c.evolucaoPercentual).toFixed(2)}%</TableCell>
-                    <TableCell sx={{ color: "#E5E7EB" }}>{safe(c.produtosForaPercentual).toFixed(2)}%</TableCell>
+                  <TableRow
+                    key={`${c.grupo}-${c.comprador}`}
+                    sx={{ "&:hover": { background: "#0F1923" }, "& td": { borderBottom: "1px solid #111827", py: 0.6 } }}
+                  >
+                    <TableCell sx={{ color: "#E5E7EB", fontSize: "0.78rem" }}>{c.comprador}</TableCell>
+                    <TableCell sx={{ color: "#94A3B8", fontSize: "0.78rem" }}>{c.grupo}</TableCell>
+                    <TableCell sx={{ color: "#E5E7EB", fontSize: "0.78rem" }}>{safe(c.vendaPercentualMeta).toFixed(1)}%</TableCell>
+                    <TableCell sx={{ color: "#E5E7EB", fontSize: "0.78rem" }}>{safe(c.lbPercentual).toFixed(1)}%</TableCell>
+                    <TableCell sx={{ color: "#6B7280", fontSize: "0.78rem" }}>{safe(c.metaLb).toFixed(1)}%</TableCell>
+                    <TableCell sx={{ color: safe(c.evolucaoPercentual) >= 0 ? "#22C55E" : "#EF4444", fontSize: "0.78rem" }}>
+                      {safe(c.evolucaoPercentual) >= 0 ? "+" : ""}{safe(c.evolucaoPercentual).toFixed(1)}%
+                    </TableCell>
+                    <TableCell sx={{ color: "#E5E7EB", fontSize: "0.78rem" }}>{safe(c.produtosForaPercentual).toFixed(1)}%</TableCell>
                     <TableCell>
-                      <Chip label={c.status} color={statusColor(safe(c.vendaPercentualMeta))} size="small" />
+                      <Chip
+                        label={c.status}
+                        color={statusColor(safe(c.vendaPercentualMeta))}
+                        size="small"
+                        sx={{ fontSize: "0.65rem", height: 20 }}
+                      />
                     </TableCell>
                   </TableRow>
                 ))}
               </TableBody>
             </Table>
           ) : (
-            <Typography variant="body2" color="#6B7280">
+            <Typography sx={{ color: "#4B5563", fontSize: "0.8rem" }}>
               Nenhum comprador com dados para o período atual.
             </Typography>
           )}
         </CardContent>
       </Card>
 
-      {/* Alertas */}
-      <Card sx={{ background: "#111827", borderRadius: 3 }}>
-        <CardContent>
-          <Typography variant="h6" mb={1}>Alertas</Typography>
-          <Stack spacing={1}>
-            {data.alertas?.length
-              ? data.alertas.map((alerta: string, idx: number) => (
-                  <Alert key={idx} severity="warning">{alerta}</Alert>
-                ))
-              : <Alert severity="success">Sem alertas críticos no momento.</Alert>}
+      {/* ── Gráficos de barras (% atingimento) ── */}
+      <Grid container spacing={1.5} mb={1.5}>
+        {[
+          { title: "Atingimento de Vendas (%)", dados: data.graficos?.evolucaoVendas },
+          { title: "Atingimento de LB (%)", dados: data.graficos?.evolucaoLb },
+        ].map(({ title, dados }) => (
+          <Grid item xs={12} md={6} key={title}>
+            <Card sx={{ background: "#0D1117", border: "1px solid #1E293B", borderRadius: 2 }}>
+              <CardContent sx={{ p: "12px !important" }}>
+                <Typography sx={{ fontWeight: 700, fontSize: "0.78rem", mb: 1, color: "#94A3B8", textTransform: "uppercase", letterSpacing: "0.06em" }}>
+                  {title}
+                </Typography>
+                <Stack spacing={0.75}>
+                  {dados?.length ? (
+                    dados.map((item: any) => (
+                      <Box key={item.label}>
+                        <Box sx={{ display: "flex", justifyContent: "space-between", mb: 0.25 }}>
+                          <Typography sx={{ fontSize: "0.72rem", color: "#CBD5E1" }}>{item.label}</Typography>
+                          <Typography sx={{ fontSize: "0.72rem", color: "#CBD5E1" }}>{safe(item.valor).toFixed(1)}%</Typography>
+                        </Box>
+                        <LinearProgress
+                          variant="determinate"
+                          value={Math.max(0, Math.min(100, safe(item.valor)))}
+                          color={statusColor(safe(item.valor))}
+                          sx={{ height: 5, borderRadius: 1 }}
+                        />
+                      </Box>
+                    ))
+                  ) : (
+                    <Typography sx={{ fontSize: "0.75rem", color: "#4B5563" }}>Sem dados para o período.</Typography>
+                  )}
+                </Stack>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+
+      {/* ── Alertas ── */}
+      <Card sx={{ background: "#0D1117", border: "1px solid #1E293B", borderRadius: 2 }}>
+        <CardContent sx={{ p: "12px !important" }}>
+          <Typography sx={{ fontWeight: 700, fontSize: "0.78rem", mb: 1, color: "#94A3B8", textTransform: "uppercase", letterSpacing: "0.06em" }}>
+            Alertas
+          </Typography>
+          <Stack spacing={0.75}>
+            {data.alertas?.length ? (
+              data.alertas.map((alerta: string, idx: number) => (
+                <Alert key={idx} severity="warning" sx={{ py: 0.25, fontSize: "0.75rem" }}>{alerta}</Alert>
+              ))
+            ) : (
+              <Alert severity="success" sx={{ py: 0.25, fontSize: "0.75rem" }}>Sem alertas críticos no momento.</Alert>
+            )}
           </Stack>
         </CardContent>
       </Card>


### PR DESCRIPTION
…s cards

- Backend: adiciona query de métricas globais via vs_scc_festoques (nivel_servico, dias_estoque), série diária para sparklines e valores R$ brutos (vendas, LB, produtos fora) com comparativo vs mês anterior
- Frontend: redesign completo do cabeçalho com 6 cards KPI estilizados (ícone colorido, valor principal, meta, tendência vs mês anterior, sparkline SVG), relógio em tempo real e tabela de compradores atualizada