### PR TITLE
Dashboard TV Compras: melhorias visuais, regras de negócio e tabela em matriz

### DIFF
--- a/backend/src/services/dashboardTvComprasService.ts
+++ b/backend/src/services/dashboardTvComprasService.ts
@@ -468,6 +468,34 @@ export const getDashboardTvCompras = async () => {
   const metaProdutosForaAjustada = totalDias > 0
     ? Math.round(safe(gm.meta_produtos_fora) * diasDecorridos / totalDias) : safe(gm.meta_produtos_fora)
 
+  // ── Dados por comprador+grupo (para a tabela matriz) ────────────────────
+  const compradoresGrupos = r1.rows.map((row: any) => {
+    const codgrp = String(row.codgrp).trim()
+    const mg = metricsGrupoMap.get(codgrp)
+    const vendaBruta = safe(row.venda_bruta)
+    const lbRealizado = safe(row.lb_realizado)
+    const lbPct = vendaBruta > 0 ? (lbRealizado / vendaBruta) * 100 : 0
+    const metaVendasAjustada = safe(row.meta_vendas_ajustada)
+    const vendaRealizado = safe(row.venda_realizado)
+    const vendaPercentualMeta = metaVendasAjustada > 0 ? (vendaRealizado / metaVendasAjustada) * 100 : 0
+    const metaProdutosForaAjustada = safe(row.meta_produtos_fora_ajustada)
+    const vendaForaRealizado = safe(row.venda_fora_realizado)
+    const produtosForaPct = metaProdutosForaAjustada > 0 ? (vendaForaRealizado / metaProdutosForaAjustada) * 100 : 0
+    return {
+      comprador: row.comprador,
+      codgrp,
+      grupoNome: String(row.grupo_nome || row.codgrp).trim(),
+      vendaPercentualMeta: Number(vendaPercentualMeta.toFixed(1)),
+      lbPercentual: Number(lbPct.toFixed(1)),
+      metaLb: Number(safe(row.meta_lb).toFixed(1)),
+      nivelServico: mg ? Number(mg.nivelServico.toFixed(1)) : null,
+      nivelServicoMeta: safe(row.meta_nivel_servico) || 97,
+      diasEstoque: mg ? Math.round(mg.diasEstoque) : null,
+      diasEstoqueMeta: safe(row.meta_dias_estoque) || 45,
+      produtosForaPercentual: Number(produtosForaPct.toFixed(1)),
+    }
+  })
+
   // Evolução vs ano passado (regra 6 — sem meta)
   const evolucao = vendasAnoPassado > 0
     ? Number(((vendasValor / vendasAnoPassado - 1) * 100).toFixed(1))
@@ -540,6 +568,7 @@ export const getDashboardTvCompras = async () => {
   return {
     kpis,
     compradores,
+    compradoresGrupos,
     series,
     seriesAnt,
     ruptura,

--- a/frontend/src/pages/TvCompras.tsx
+++ b/frontend/src/pages/TvCompras.tsx
@@ -348,11 +348,22 @@ export default function TvCompras() {
 
   const kpis = data.kpis ?? {}
   const comps: any[]      = data.compradores ?? []
+  const gruposFlat: any[] = data.compradoresGrupos ?? []
   const series: any[]     = data.series ?? []
   const seriesAnt: any[]  = data.seriesAnt ?? []
   const ruptura: any[]    = data.ruptura ?? []
   const sit               = data.situacaoEstoque ?? {}
   const graficos          = data.graficos ?? {}
+
+  // Agrupa para a tabela matriz: [{comprador, grupos:[...]}]
+  const matrizCompradores = (() => {
+    const map = new Map<string, any[]>()
+    for (const g of gruposFlat) {
+      if (!map.has(g.comprador)) map.set(g.comprador, [])
+      map.get(g.comprador)!.push(g)
+    }
+    return Array.from(map.entries()).map(([comprador, grupos]) => ({ comprador, grupos }))
+  })()
 
   // Séries cumulativas
   const cumul = (rows: any[], field: string) => {
@@ -532,7 +543,7 @@ export default function TvCompras() {
         </div>
       </div>
 
-      {/* ── TABELA DE COMPRADORES ── */}
+      {/* ── TABELA MATRIZ: COMPRADOR × GRUPO ── */}
       <div style={{ background: C.card, border: `1px solid ${C.border}`, borderRadius: 8, padding: "8px 10px", marginBottom: 10, overflowX: "auto" }}>
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 6 }}>
           <span style={{ color: C.blue, fontWeight: 700, fontSize: 11, letterSpacing: "0.08em" }}>👥 DESEMPENHO POR COMPRADOR E GRUPO</span>
@@ -542,42 +553,54 @@ export default function TvCompras() {
           <thead>
             <tr>
               <th style={{ ...th }} rowSpan={2}>Comprador</th>
-              <th style={{ ...th }} rowSpan={2}>Grupos</th>
+              <th style={{ ...th }} rowSpan={2}>Grupo</th>
               <th style={{ ...thG, textAlign: "center" }} rowSpan={2}>Vendas<br/>Atingimento</th>
               <th style={{ ...thG, textAlign: "center" }} colSpan={2}>LB (%)</th>
               <th style={{ ...thG, textAlign: "center" }} colSpan={2}>Nível Serviço (%)</th>
               <th style={{ ...thG, textAlign: "center" }} colSpan={2}>Dias Estoque</th>
               <th style={{ ...thG, textAlign: "center" }} rowSpan={2}>Prod. Fora<br/>Atingimento</th>
-              <th style={{ ...thG }} rowSpan={2}>Status</th>
+              <th style={{ ...thG }} rowSpan={2}>Metas</th>
             </tr>
             <tr>
-              <th style={thG}>Realizado</th><th style={th}>Meta</th>
-              <th style={thG}>Realizado</th><th style={th}>Meta</th>
-              <th style={thG}>Realizado</th><th style={th}>Meta</th>
+              <th style={thG}>Real.</th><th style={th}>Meta</th>
+              <th style={thG}>Real.</th><th style={th}>Meta</th>
+              <th style={thG}>Real.</th><th style={th}>Meta</th>
             </tr>
           </thead>
           <tbody>
-            {comps.length > 0 ? comps.map((c: any, i: number) => (
-              <tr key={i} style={{ background: i % 2 === 1 ? "#060C1A" : "transparent" }}>
-                <td style={td}>{c.comprador}</td>
-                <td style={tdN}>{c.grupos}</td>
-                <td style={tdG}><AtingBar pct={safe(c.vendaPercentualMeta)} /></td>
-                <td style={{ ...tdG, color: safe(c.lbPercentual) >= safe(c.metaLb) ? C.green : C.red, fontWeight: 700 }}>
-                  {fmtP(safe(c.lbPercentual))}
-                </td>
-                <td style={tdN}>{fmtP(safe(c.metaLb))}</td>
-                <td style={{ ...tdG, color: safe(c.nivelServico) >= (c.nivelServicoMeta || 97) ? C.green : C.red, fontWeight: 700 }}>
-                  {c.nivelServico !== null ? fmtP(safe(c.nivelServico)) : "—"}
-                </td>
-                <td style={tdN}>{fmtP(c.nivelServicoMeta || 97)}</td>
-                <td style={{ ...tdG, color: safe(c.diasEstoque) <= (c.diasEstoqueMeta || 45) ? C.green : safe(c.diasEstoque) <= 55 ? C.orange : C.red, fontWeight: 700 }}>
-                  {c.diasEstoque !== null ? `${Math.round(safe(c.diasEstoque))}` : "—"}
-                </td>
-                <td style={tdN}>{c.diasEstoqueMeta || 45}</td>
-                <td style={tdG}><AtingBar pct={safe(c.produtosForaPercentual)} /></td>
-                <td style={tdG}><MetaIcons c={c} /></td>
-              </tr>
-            )) : (
+            {matrizCompradores.length > 0 ? matrizCompradores.map((m, mi) =>
+              m.grupos.map((g: any, gi: number) => {
+                const rowBg = mi % 2 === 1 ? "#060C1A" : "transparent"
+                const sepStyle: React.CSSProperties = gi === 0 && mi > 0
+                  ? { borderTop: `2px solid ${C.border}` } : {}
+                return (
+                  <tr key={`${mi}-${gi}`} style={{ background: rowBg }}>
+                    {gi === 0 && (
+                      <td style={{ ...td, ...sepStyle, verticalAlign: "top", fontWeight: 700, paddingTop: 6, whiteSpace: "nowrap" }}
+                        rowSpan={m.grupos.length}>
+                        {g.comprador}
+                      </td>
+                    )}
+                    <td style={{ ...tdN, ...sepStyle, fontSize: 10 }}>{g.grupoNome}</td>
+                    <td style={{ ...tdG, ...sepStyle }}><AtingBar pct={safe(g.vendaPercentualMeta)} /></td>
+                    <td style={{ ...tdG, ...sepStyle, color: safe(g.lbPercentual) >= safe(g.metaLb) ? C.green : C.red, fontWeight: 700 }}>
+                      {fmtP(safe(g.lbPercentual))}
+                    </td>
+                    <td style={{ ...tdN, ...sepStyle }}>{fmtP(safe(g.metaLb))}</td>
+                    <td style={{ ...tdG, ...sepStyle, color: g.nivelServico !== null && safe(g.nivelServico) >= (g.nivelServicoMeta || 97) ? C.green : C.red, fontWeight: 700 }}>
+                      {g.nivelServico !== null ? fmtP(safe(g.nivelServico)) : "—"}
+                    </td>
+                    <td style={{ ...tdN, ...sepStyle }}>{fmtP(g.nivelServicoMeta || 97)}</td>
+                    <td style={{ ...tdG, ...sepStyle, color: g.diasEstoque !== null && safe(g.diasEstoque) <= (g.diasEstoqueMeta || 45) ? C.green : safe(g.diasEstoque) <= 55 ? C.orange : C.red, fontWeight: 700 }}>
+                      {g.diasEstoque !== null ? `${Math.round(safe(g.diasEstoque))}` : "—"}
+                    </td>
+                    <td style={{ ...tdN, ...sepStyle }}>{g.diasEstoqueMeta || 45}</td>
+                    <td style={{ ...tdG, ...sepStyle }}><AtingBar pct={safe(g.produtosForaPercentual)} /></td>
+                    <td style={{ ...tdG, ...sepStyle }}><MetaIcons c={g} /></td>
+                  </tr>
+                )
+              })
+            ) : (
               <tr><td colSpan={11} style={{ ...td, textAlign: "center", color: C.muted }}>Nenhum dado disponível</td></tr>
             )}
           </tbody>


### PR DESCRIPTION
## Resumo

Conjunto de melhorias iterativas no Dashboard TV Compras implementadas após o PR #110 (fechado).

## O que mudou

### Cards KPI
- **Indicador de meta em todos os cards**: badge colorido (▲ ACIMA / ≈ PRÓXIMO / ▼ ABAIXO) + mini barra de progresso substituem as sparklines
- Cards **Vendas** e **Produtos Fora** exibem % atingido em vez de valor R$
- Card **LB**: trend vs mês anterior removido
- Card **DIAS DE ESTOQUE**: meta vem da média de `meta_dias_estoque` do banco (não mais hardcoded 45)
- Card **NS**: meta vem do banco (`meta_nivel_servico_media`)

### Tabela DESEMPENHO POR COMPRADOR E GRUPO
- **Matriz comprador×grupo**: uma linha por grupo, nome do comprador em `rowSpan`; separador entre compradores
- Coluna **Status** substituída por **5 ícones V/L/N/D/P** (✓ verde / ✗ vermelho por meta)
- Separadores visuais entre grupos de colunas; **LB colorido** (verde/vermelho vs meta)
- **AtingBar** ampliada de 50px → 80px

### Gráficos
- **BarChartH**: trilho de fundo, linha META branca visível, faixa verde de zona atingida
- **Donut SITUAÇÃO DO ESTOQUE**: legenda HTML abaixo do SVG (corrige overflow); faixas de dias (≤15d Crítico, 16-90d Normal, >90d Excesso)
- **Ruptura**: exclui produtos com pedido pendente no fornecedor (`vs_scc_pedidos_compra_pendente`); legenda explicativa

### Autenticação
- Rota `/tv-compras` acessível sem login (`AuthContext` excluída do redirect)

### Outros
- Rodapé removido

## Arquivos alterados
- `backend/src/services/dashboardTvComprasService.ts`
- `frontend/src/contexts/AuthContext.tsx`
- `frontend/src/pages/TvCompras.tsx`