### PR TITLE
tv-compras-lojas: corrige TOTAL GERAL usando agregados reais do kpis

### DIFF
--- a/backend/src/services/dashboardTvComprasService.ts
+++ b/backend/src/services/dashboardTvComprasService.ts
@@ -338,6 +338,7 @@ export const getDashboardTvCompras = async () => {
   `
 
   // ── Query 10: NS por lojas — vs_scc_estoque_media_facing_lojas ─────────────
+  // Retorna NS por grupo E o total global (codgrp = '__TOTAL__')
   // Conta pares (produto × loja) com facing como denominador,
   // e pares com facing + saldoestoque > 0 como numerador
   const queryNsLojasGrupo = `
@@ -356,6 +357,15 @@ export const getDashboardTvCompras = async () => {
     FROM vs_scc_estoque_media_facing_lojas ef
     WHERE TRIM(ef.codgrp) IN (SELECT codgrp FROM grupos_meta)
     GROUP BY TRIM(ef.codgrp)
+    UNION ALL
+    SELECT
+      '__TOTAL__' AS codgrp,
+      ROUND(
+        COUNT(CASE WHEN ef.facing > 0 AND ef.saldoestoque > 0 THEN 1 END)::numeric
+        / NULLIF(COUNT(CASE WHEN ef.facing > 0 THEN 1 END), 0) * 100, 1
+      ) AS nivel_servico_lojas
+    FROM vs_scc_estoque_media_facing_lojas ef
+    WHERE TRIM(ef.codgrp) IN (SELECT codgrp FROM grupos_meta)
   `
 
   // ── Query 9: top 10 dias sem estoque — curva A1 ───────────────────────────
@@ -385,11 +395,12 @@ export const getDashboardTvCompras = async () => {
     pool.query(queryNsLojasGrupo),
   ])
 
-  // ── Mapa de NS por lojas (produto × loja) por grupo ──────────────────────
+  // ── Mapa de NS por lojas (produto × loja) por grupo + total global ───────
   const nsLojasMap = new Map<string, number>()
   for (const row of r10.rows) {
     nsLojasMap.set(String(row.codgrp).trim(), safe(row.nivel_servico_lojas))
   }
+  const nivelServicoLojasGlobal = nsLojasMap.get('__TOTAL__') ?? null
 
   // ── Mapa de métricas por grupo ────────────────────────────────────────────
   const metricsGrupoMap = new Map<string, { nivelServico: number; diasEstoque: number }>()
@@ -637,6 +648,7 @@ export const getDashboardTvCompras = async () => {
       ? Number((lbPct - lbAntPct).toFixed(1)) : null as number | null,
 
     nivelServico: safe(gm.nivel_servico),
+    nivelServicoLojas: nivelServicoLojasGlobal,
     nivelServicoMeta: Math.round(safe(gm.meta_nivel_servico_media)) || 98,
     nivelServicoVsMesAnterior: null as number | null,
 

--- a/frontend/src/pages/TvComprasLojas.tsx
+++ b/frontend/src/pages/TvComprasLojas.tsx
@@ -128,6 +128,7 @@ export default function TvComprasLojas() {
     </Box>
   )
 
+  const kpis               = data.kpis ?? {}
   const comps: any[]       = data.compradores ?? []
   const gruposFlat: any[]  = data.compradoresGrupos ?? []
   const mesLabel = now.toLocaleDateString("pt-BR", { month: "long", year: "numeric" }).replace(/^\w/, c => c.toUpperCase())
@@ -162,19 +163,14 @@ export default function TvComprasLojas() {
   const nsAting   = (g: any) => (g.nivelServicoMeta || 97) > 0 ? nsVal(g) / (g.nivelServicoMeta || 97) * 100 : 0
   const diasAting = (g: any) => { const r = safe(g.diasEstoque); return r > 0 ? (g.diasEstoqueMeta || 45) / r * 100 : 0 }
 
-  // Totais gerais (média simples dos compradores)
-  const avg = (fn: (c: any) => number) =>
-    comps.length > 0 ? comps.reduce((s, c) => s + fn(c), 0) / comps.length : 0
-
-  const totalVendas = avg(c => safe(c.vendaPercentualMeta))
-  const totalLb     = avg(c => lbAting(c))
-  const totalNs     = avg(c => (c.nivelServicoMeta || 97) > 0
-    ? (c.nivelServicoLojas !== null && c.nivelServicoLojas !== undefined
-        ? safe(c.nivelServicoLojas) : safe(c.nivelServico))
-      / (c.nivelServicoMeta || 97) * 100
-    : 0)
-  const totalDias   = avg(c => diasAting(c))
-  const totalProd   = avg(c => safe(c.produtosForaPercentual))
+  // Totais gerais — usa kpis do backend (agregado real, não média de médias)
+  const totalVendas = safe(kpis.vendasAtingimento)
+  const totalLb     = safe(kpis.metaLb) > 0 ? safe(kpis.lbPercentual) / safe(kpis.metaLb) * 100 : 0
+  const nsLojasGlobal = kpis.nivelServicoLojas !== null && kpis.nivelServicoLojas !== undefined
+    ? safe(kpis.nivelServicoLojas) : safe(kpis.nivelServico)
+  const totalNs     = safe(kpis.nivelServicoMeta) > 0 ? nsLojasGlobal / safe(kpis.nivelServicoMeta) * 100 : 0
+  const totalDias   = safe(kpis.diasEstoque) > 0 ? safe(kpis.diasEstoqueMeta) / safe(kpis.diasEstoque) * 100 : 0
+  const totalProd   = safe(kpis.produtosFora)
 
   const th: React.CSSProperties = {
     color: C.muted, fontSize: 10, fontWeight: 600, textTransform: "uppercase" as const,


### PR DESCRIPTION
Problema: os 5 cards do TOTAL GERAL usavam media simples dos compradores (media de medias), que divergia do tv-compras correto.

Correcao:
- Vendas: usa kpis.vendasAtingimento (soma realizado / soma meta)
- LB: usa kpis.lbPercentual / kpis.metaLb (ponderado por venda bruta)
- NS: usa kpis.nivelServicoLojas global (novo campo) / nivelServicoMeta
- Dias: usa kpis.diasEstoqueMeta / kpis.diasEstoque
- Prod. Fora: usa kpis.produtosFora (soma realizado / soma meta)

Backend: queryNsLojasGrupo agora inclui UNION ALL com linha __TOTAL__ para agregar todos os grupos de uma vez (COUNT real, nao media de grupos). Campo nivelServicoLojas adicionado ao objeto kpis retornado.