### PR TITLE
tv-compras-lojas: NS por loja com chips visuais por codgrp e sub-total

### DIFF
--- a/backend/src/services/dashboardTvComprasService.ts
+++ b/backend/src/services/dashboardTvComprasService.ts
@@ -368,6 +368,53 @@ export const getDashboardTvCompras = async () => {
     WHERE TRIM(ef.codgrp) IN (SELECT codgrp FROM grupos_meta)
   `
 
+  // ── Query 11: NS por loja, detalhado por codgrp e por comprador ─────────────
+  // Retorna duas séries via UNION:
+  //   tipo='grupo'    → codgrp + codloja (para cada linha de grupo na tabela)
+  //   tipo='comprador' → comprador + codloja (para a linha de sub-total)
+  const queryNsLojasDetalhe = `
+    WITH
+    grupos_meta AS (
+      SELECT DISTINCT TRIM(codgrp) AS codgrp
+      FROM scc_metas_compradores
+      WHERE mes = EXTRACT(MONTH FROM CURRENT_DATE)::int
+        AND ano = EXTRACT(YEAR  FROM CURRENT_DATE)::int
+    ),
+    ga AS (
+      SELECT TRIM(cg.codgrp) AS codgrp, c.nome AS comprador
+      FROM scc_comprador_grupo cg
+      JOIN scc_compradores c ON c.id = cg.comprador_id
+      WHERE cg.dt_fim IS NULL
+        AND TRIM(cg.codgrp) IN (SELECT codgrp FROM grupos_meta)
+    )
+    SELECT
+      'grupo'              AS tipo,
+      TRIM(ef.codgrp)      AS codgrp,
+      NULL::text           AS comprador,
+      TRIM(ef.codloja)     AS codloja,
+      ROUND(
+        COUNT(CASE WHEN ef.facing > 0 AND ef.saldoestoque > 0 THEN 1 END)::numeric
+        / NULLIF(COUNT(CASE WHEN ef.facing > 0 THEN 1 END), 0) * 100, 0
+      ) AS nivel_servico
+    FROM vs_scc_estoque_media_facing_lojas ef
+    WHERE TRIM(ef.codgrp) IN (SELECT codgrp FROM grupos_meta)
+    GROUP BY TRIM(ef.codgrp), TRIM(ef.codloja)
+    UNION ALL
+    SELECT
+      'comprador'          AS tipo,
+      NULL::text           AS codgrp,
+      ga.comprador,
+      TRIM(ef.codloja)     AS codloja,
+      ROUND(
+        COUNT(CASE WHEN ef.facing > 0 AND ef.saldoestoque > 0 THEN 1 END)::numeric
+        / NULLIF(COUNT(CASE WHEN ef.facing > 0 THEN 1 END), 0) * 100, 0
+      ) AS nivel_servico
+    FROM vs_scc_estoque_media_facing_lojas ef
+    JOIN ga ON ga.codgrp = TRIM(ef.codgrp)
+    GROUP BY ga.comprador, TRIM(ef.codloja)
+    ORDER BY tipo, codgrp, comprador, codloja
+  `
+
   // ── Query 9: top 10 dias sem estoque — curva A1 ───────────────────────────
   const queryRupturaCurvaA = `
     SELECT
@@ -382,7 +429,7 @@ export const getDashboardTvCompras = async () => {
     LIMIT 10
   `
 
-  const [r1, r2, r3, r4, r5, r6, r7, r8, r9, r10] = await Promise.all([
+  const [r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11] = await Promise.all([
     pool.query(queryCompradores),
     pool.query(queryGlobal),
     pool.query(querySeries),
@@ -393,6 +440,7 @@ export const getDashboardTvCompras = async () => {
     pool.query(queryNsHistorico),
     pool.query(queryRupturaCurvaA),
     pool.query(queryNsLojasGrupo),
+    pool.query(queryNsLojasDetalhe),
   ])
 
   // ── Mapa de NS por lojas (produto × loja) por grupo + total global ───────
@@ -401,6 +449,24 @@ export const getDashboardTvCompras = async () => {
     nsLojasMap.set(String(row.codgrp).trim(), safe(row.nivel_servico_lojas))
   }
   const nivelServicoLojasGlobal = nsLojasMap.get('__TOTAL__') ?? null
+
+  // ── Mapa NS por loja: codgrp → [{codloja, nivelServico}] ─────────────────
+  const nsLojasDetalheGrupoMap = new Map<string, { codloja: string; nivelServico: number }[]>()
+  // ── Mapa NS por loja: comprador → [{codloja, nivelServico}] (sub-totais) ──
+  const nsLojasDetalheCompMap  = new Map<string, { codloja: string; nivelServico: number }[]>()
+  for (const row of r11.rows) {
+    const ns = safe(row.nivel_servico)
+    const loja = String(row.codloja).trim()
+    if (row.tipo === 'grupo') {
+      const key = String(row.codgrp).trim()
+      if (!nsLojasDetalheGrupoMap.has(key)) nsLojasDetalheGrupoMap.set(key, [])
+      nsLojasDetalheGrupoMap.get(key)!.push({ codloja: loja, nivelServico: ns })
+    } else {
+      const key = String(row.comprador).trim()
+      if (!nsLojasDetalheCompMap.has(key)) nsLojasDetalheCompMap.set(key, [])
+      nsLojasDetalheCompMap.get(key)!.push({ codloja: loja, nivelServico: ns })
+    }
+  }
 
   // ── Mapa de métricas por grupo ────────────────────────────────────────────
   const metricsGrupoMap = new Map<string, { nivelServico: number; diasEstoque: number }>()
@@ -519,6 +585,7 @@ export const getDashboardTvCompras = async () => {
       vendaPercentualMeta: Number(vendaMeta.toFixed(1)),
       lbPercentual: Number(lbPct.toFixed(1)),
       metaLb: Number(metaLb.toFixed(1)),
+      nsPorLoja: nsLojasDetalheCompMap.get(c.comprador) ?? [],
       nivelServico: nsMedia !== null ? Number(nsMedia!.toFixed(1)) : null,
       nivelServicoLojas: c.nivelServicoLojasCount > 0
         ? Number((c.nivelServicoLojasSum / c.nivelServicoLojasCount).toFixed(1))
@@ -580,6 +647,7 @@ export const getDashboardTvCompras = async () => {
       metaLb: Number(safe(row.meta_lb).toFixed(1)),
       nivelServico: mg ? Number(mg.nivelServico.toFixed(1)) : null,
       nivelServicoLojas: nsLojasMap.has(codgrp) ? Number(nsLojasMap.get(codgrp)!.toFixed(1)) : null,
+      nsPorLoja: nsLojasDetalheGrupoMap.get(codgrp) ?? [],
       nivelServicoMeta: safe(row.meta_nivel_servico) || 97,
       diasEstoque: mg ? Math.round(mg.diasEstoque) : null,
       diasEstoqueMeta: safe(row.meta_dias_estoque) || 45,

--- a/frontend/src/pages/TvComprasLojas.tsx
+++ b/frontend/src/pages/TvComprasLojas.tsx
@@ -63,6 +63,51 @@ function TotalCard({ icon, label, pct }: { icon: string; label: string; pct: num
   )
 }
 
+// ─── Chips de NS por loja ─────────────────────────────────────────────────────
+function NsLojaChips({ lojas, meta = 97, overall }: {
+  lojas: { codloja: string; nivelServico: number }[]
+  meta?: number
+  overall?: number
+}) {
+  if (!lojas.length) return <span style={{ color: C.muted, fontSize: 11 }}>—</span>
+  const overallColor = overall !== undefined
+    ? (overall >= meta ? C.green : overall >= meta * 0.9 ? C.orange : C.red)
+    : C.muted
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      {overall !== undefined && (
+        <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+          <span style={{ fontSize: 12, fontWeight: 800, color: overallColor, fontVariantNumeric: "tabular-nums" }}>
+            {overall.toFixed(0)}%
+          </span>
+          <div style={{ flex: 1, height: 4, background: C.dim, borderRadius: 2, overflow: "hidden" }}>
+            <div style={{ width: `${Math.min(100, overall / meta * 100)}%`, height: "100%", background: overallColor, borderRadius: 2 }} />
+          </div>
+        </div>
+      )}
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
+        {lojas.map(l => {
+          const ns = l.nivelServico
+          const color = ns >= meta ? C.green : ns >= meta * 0.9 ? C.orange : C.red
+          return (
+            <div key={l.codloja} style={{
+              display: "flex", flexDirection: "column", alignItems: "center",
+              background: color + "1A",
+              border: `1px solid ${color}55`,
+              borderRadius: 3,
+              padding: "1px 4px",
+              minWidth: 26,
+            }}>
+              <span style={{ fontSize: 7, color: C.muted, lineHeight: 1.2 }}>{l.codloja}</span>
+              <span style={{ fontSize: 9, color, fontWeight: 700, lineHeight: 1.2, fontVariantNumeric: "tabular-nums" }}>{ns}%</span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
 // ─── Ícones de meta (V L N D P) ──────────────────────────────────────────────
 function MetaIcons({ c }: { c: any }) {
   // NS usa nivelServicoLojas se disponível, caso contrário nivelServico
@@ -273,7 +318,11 @@ export default function TvComprasLojas() {
                     <td style={{ ...tdG, ...sepStyle }}><AtingBar pct={safe(g.vendaPercentualMeta)} /></td>
                     <td style={{ ...tdG, ...sepStyle }}><AtingBar pct={lbAting(g)} /></td>
                     <td style={{ ...tdG, ...sepStyle }}>
-                      {nsPresent(g) ? <AtingBar pct={nsAting(g)} /> : <span style={{ color: C.muted }}>—</span>}
+                      <NsLojaChips
+                        lojas={g.nsPorLoja ?? []}
+                        meta={g.nivelServicoMeta || 97}
+                        overall={nsPresent(g) ? nsVal(g) : undefined}
+                      />
                     </td>
                     <td style={{ ...tdG, ...sepStyle }}>
                       {g.diasEstoque !== null ? <AtingBar pct={diasAting(g)} /> : <span style={{ color: C.muted }}>—</span>}
@@ -294,7 +343,11 @@ export default function TvComprasLojas() {
                   <td style={tdSubG}><AtingBar pct={safe(sub.vendaPercentualMeta)} height={8} /></td>
                   <td style={tdSubG}><AtingBar pct={lbAting(sub)} height={8} /></td>
                   <td style={tdSubG}>
-                    {nsPresent(sub) ? <AtingBar pct={nsAting(sub)} height={8} /> : <span style={{ color: C.muted }}>—</span>}
+                    <NsLojaChips
+                      lojas={sub.nsPorLoja ?? []}
+                      meta={sub.nivelServicoMeta || 97}
+                      overall={nsPresent(sub) ? nsVal(sub) : undefined}
+                    />
                   </td>
                   <td style={tdSubG}>
                     {sub.diasEstoque !== null ? <AtingBar pct={diasAting(sub)} height={8} /> : <span style={{ color: C.muted }}>—</span>}


### PR DESCRIPTION
Coluna Nivel Servico na tabela agora exibe chips individuais por loja (00 a 11/15) mostrando o NS% de cada uma, coloridos verde/laranja/vermelho. Acima dos chips, mostra o NS geral do grupo com mini barra de progresso.

Backend:
- Query 11 (queryNsLojasDetalhe): NS por (codgrp, codloja) e por (comprador, codloja) via UNION, usando vs_scc_estoque_media_facing_lojas
- Campo nsPorLoja adicionado em compradoresGrupos (por grupo) e em compradores (por comprador, para sub-totais)

Frontend:
- Componente NsLojaChips: overall% com barra + chips por loja
- Celula NS de grupos e sub-totais usam NsLojaChips