### PR TITLE
tv-compras-lojas: chips por loja em NS e Dias Estoque

### DIFF
--- a/backend/src/services/dashboardTvComprasService.ts
+++ b/backend/src/services/dashboardTvComprasService.ts
@@ -395,7 +395,11 @@ export const getDashboardTvCompras = async () => {
       ROUND(
         COUNT(CASE WHEN ef.facing > 0 AND ef.saldoestoque > 0 THEN 1 END)::numeric
         / NULLIF(COUNT(CASE WHEN ef.facing > 0 THEN 1 END), 0) * 100, 0
-      ) AS nivel_servico
+      ) AS nivel_servico,
+      ROUND(
+        SUM(CASE WHEN ef.mediadia > 0 THEN ef.saldoestoque ELSE 0 END)
+        / NULLIF(SUM(CASE WHEN ef.mediadia > 0 THEN ef.mediadia ELSE 0 END), 0), 0
+      ) AS dias_estoque
     FROM vs_scc_estoque_media_facing_lojas ef
     WHERE TRIM(ef.codgrp) IN (SELECT codgrp FROM grupos_meta)
     GROUP BY TRIM(ef.codgrp), TRIM(ef.codloja)
@@ -408,7 +412,11 @@ export const getDashboardTvCompras = async () => {
       ROUND(
         COUNT(CASE WHEN ef.facing > 0 AND ef.saldoestoque > 0 THEN 1 END)::numeric
         / NULLIF(COUNT(CASE WHEN ef.facing > 0 THEN 1 END), 0) * 100, 0
-      ) AS nivel_servico
+      ) AS nivel_servico,
+      ROUND(
+        SUM(CASE WHEN ef.mediadia > 0 THEN ef.saldoestoque ELSE 0 END)
+        / NULLIF(SUM(CASE WHEN ef.mediadia > 0 THEN ef.mediadia ELSE 0 END), 0), 0
+      ) AS dias_estoque
     FROM vs_scc_estoque_media_facing_lojas ef
     JOIN ga ON ga.codgrp = TRIM(ef.codgrp)
     GROUP BY ga.comprador, TRIM(ef.codloja)
@@ -450,22 +458,17 @@ export const getDashboardTvCompras = async () => {
   }
   const nivelServicoLojasGlobal = nsLojasMap.get('__TOTAL__') ?? null
 
-  // ── Mapa NS por loja: codgrp → [{codloja, nivelServico}] ─────────────────
-  const nsLojasDetalheGrupoMap = new Map<string, { codloja: string; nivelServico: number }[]>()
-  // ── Mapa NS por loja: comprador → [{codloja, nivelServico}] (sub-totais) ──
-  const nsLojasDetalheCompMap  = new Map<string, { codloja: string; nivelServico: number }[]>()
+  // ── Mapas NS e Dias por loja (apenas para linhas de grupo — sub-totais usam AtingBar) ──
+  const nsLojasDetalheGrupoMap   = new Map<string, { codloja: string; nivelServico: number }[]>()
+  const diasLojasDetalheGrupoMap = new Map<string, { codloja: string; diasEstoque: number }[]>()
   for (const row of r11.rows) {
-    const ns = safe(row.nivel_servico)
+    if (row.tipo !== 'grupo') continue
     const loja = String(row.codloja).trim()
-    if (row.tipo === 'grupo') {
-      const key = String(row.codgrp).trim()
-      if (!nsLojasDetalheGrupoMap.has(key)) nsLojasDetalheGrupoMap.set(key, [])
-      nsLojasDetalheGrupoMap.get(key)!.push({ codloja: loja, nivelServico: ns })
-    } else {
-      const key = String(row.comprador).trim()
-      if (!nsLojasDetalheCompMap.has(key)) nsLojasDetalheCompMap.set(key, [])
-      nsLojasDetalheCompMap.get(key)!.push({ codloja: loja, nivelServico: ns })
-    }
+    const key  = String(row.codgrp).trim()
+    if (!nsLojasDetalheGrupoMap.has(key))   nsLojasDetalheGrupoMap.set(key, [])
+    if (!diasLojasDetalheGrupoMap.has(key)) diasLojasDetalheGrupoMap.set(key, [])
+    nsLojasDetalheGrupoMap.get(key)!.push({ codloja: loja, nivelServico: safe(row.nivel_servico) })
+    diasLojasDetalheGrupoMap.get(key)!.push({ codloja: loja, diasEstoque: safe(row.dias_estoque) })
   }
 
   // ── Mapa de métricas por grupo ────────────────────────────────────────────
@@ -585,7 +588,6 @@ export const getDashboardTvCompras = async () => {
       vendaPercentualMeta: Number(vendaMeta.toFixed(1)),
       lbPercentual: Number(lbPct.toFixed(1)),
       metaLb: Number(metaLb.toFixed(1)),
-      nsPorLoja: nsLojasDetalheCompMap.get(c.comprador) ?? [],
       nivelServico: nsMedia !== null ? Number(nsMedia!.toFixed(1)) : null,
       nivelServicoLojas: c.nivelServicoLojasCount > 0
         ? Number((c.nivelServicoLojasSum / c.nivelServicoLojasCount).toFixed(1))
@@ -647,7 +649,8 @@ export const getDashboardTvCompras = async () => {
       metaLb: Number(safe(row.meta_lb).toFixed(1)),
       nivelServico: mg ? Number(mg.nivelServico.toFixed(1)) : null,
       nivelServicoLojas: nsLojasMap.has(codgrp) ? Number(nsLojasMap.get(codgrp)!.toFixed(1)) : null,
-      nsPorLoja: nsLojasDetalheGrupoMap.get(codgrp) ?? [],
+      nsPorLoja:   nsLojasDetalheGrupoMap.get(codgrp) ?? [],
+      diasPorLoja: diasLojasDetalheGrupoMap.get(codgrp) ?? [],
       nivelServicoMeta: safe(row.meta_nivel_servico) || 97,
       diasEstoque: mg ? Math.round(mg.diasEstoque) : null,
       diasEstoqueMeta: safe(row.meta_dias_estoque) || 45,

--- a/frontend/src/pages/TvComprasLojas.tsx
+++ b/frontend/src/pages/TvComprasLojas.tsx
@@ -108,6 +108,51 @@ function NsLojaChips({ lojas, meta = 97, overall }: {
   )
 }
 
+// ─── Chips de Dias de Estoque por loja ───────────────────────────────────────
+function DiasLojaChips({ lojas, meta = 45, overall }: {
+  lojas: { codloja: string; diasEstoque: number }[]
+  meta?: number
+  overall?: number
+}) {
+  if (!lojas.length) return <span style={{ color: C.muted, fontSize: 11 }}>—</span>
+  const overallColor = overall !== undefined
+    ? (overall <= meta ? C.green : overall <= meta * 1.2 ? C.orange : C.red)
+    : C.muted
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      {overall !== undefined && (
+        <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+          <span style={{ fontSize: 12, fontWeight: 800, color: overallColor, fontVariantNumeric: "tabular-nums" }}>
+            {Math.round(overall)}d
+          </span>
+          <div style={{ flex: 1, height: 4, background: C.dim, borderRadius: 2, overflow: "hidden" }}>
+            <div style={{ width: `${Math.min(100, (meta / Math.max(overall, 1)) * 100)}%`, height: "100%", background: overallColor, borderRadius: 2 }} />
+          </div>
+        </div>
+      )}
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
+        {lojas.map(l => {
+          const d = l.diasEstoque
+          const color = d <= meta ? C.green : d <= meta * 1.2 ? C.orange : C.red
+          return (
+            <div key={l.codloja} style={{
+              display: "flex", flexDirection: "column", alignItems: "center",
+              background: color + "1A",
+              border: `1px solid ${color}55`,
+              borderRadius: 3,
+              padding: "1px 4px",
+              minWidth: 26,
+            }}>
+              <span style={{ fontSize: 7, color: C.muted, lineHeight: 1.2 }}>{l.codloja}</span>
+              <span style={{ fontSize: 9, color, fontWeight: 700, lineHeight: 1.2, fontVariantNumeric: "tabular-nums" }}>{d}d</span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
 // ─── Ícones de meta (V L N D P) ──────────────────────────────────────────────
 function MetaIcons({ c }: { c: any }) {
   // NS usa nivelServicoLojas se disponível, caso contrário nivelServico
@@ -292,8 +337,8 @@ export default function TvComprasLojas() {
               <th style={th}>Grupo</th>
               <th style={{ ...thG, textAlign: "center", minWidth: 140 }}>Vendas<br/>Atingimento</th>
               <th style={{ ...thG, textAlign: "center", minWidth: 140 }}>LB<br/>Atingimento</th>
-              <th style={{ ...thG, textAlign: "center", minWidth: 140 }}>Nível Serviço<br/>Atingimento</th>
-              <th style={{ ...thG, textAlign: "center", minWidth: 140 }}>Dias Estoque<br/>Atingimento</th>
+              <th style={{ ...thG, textAlign: "center", minWidth: 380 }}>Nível Serviço<br/>Atingimento</th>
+              <th style={{ ...thG, textAlign: "center", minWidth: 380 }}>Dias Estoque<br/>Atingimento</th>
               <th style={{ ...thG, textAlign: "center", minWidth: 140 }}>Prod. Fora<br/>Atingimento</th>
               <th style={{ ...thG, textAlign: "center" }}>Metas</th>
             </tr>
@@ -325,7 +370,11 @@ export default function TvComprasLojas() {
                       />
                     </td>
                     <td style={{ ...tdG, ...sepStyle }}>
-                      {g.diasEstoque !== null ? <AtingBar pct={diasAting(g)} /> : <span style={{ color: C.muted }}>—</span>}
+                      <DiasLojaChips
+                        lojas={g.diasPorLoja ?? []}
+                        meta={g.diasEstoqueMeta || 45}
+                        overall={g.diasEstoque !== null ? safe(g.diasEstoque) : undefined}
+                      />
                     </td>
                     <td style={{ ...tdG, ...sepStyle }}><AtingBar pct={safe(g.produtosForaPercentual)} /></td>
                     <td style={{ ...tdG, ...sepStyle }}><MetaIcons c={g} /></td>
@@ -343,11 +392,7 @@ export default function TvComprasLojas() {
                   <td style={tdSubG}><AtingBar pct={safe(sub.vendaPercentualMeta)} height={8} /></td>
                   <td style={tdSubG}><AtingBar pct={lbAting(sub)} height={8} /></td>
                   <td style={tdSubG}>
-                    <NsLojaChips
-                      lojas={sub.nsPorLoja ?? []}
-                      meta={sub.nivelServicoMeta || 97}
-                      overall={nsPresent(sub) ? nsVal(sub) : undefined}
-                    />
+                    {nsPresent(sub) ? <AtingBar pct={nsAting(sub)} height={8} /> : <span style={{ color: C.muted }}>—</span>}
                   </td>
                   <td style={tdSubG}>
                     {sub.diasEstoque !== null ? <AtingBar pct={diasAting(sub)} height={8} /> : <span style={{ color: C.muted }}>—</span>}


### PR DESCRIPTION
## O que mudou

Melhoria visual nas colunas Nivel Servico e Dias Estoque da tabela DESEMPENHO POR COMPRADOR E GRUPO em `/tv-compras-lojas`.

### Colunas NS e Dias Estoque (linhas de grupo)
- Exibem chips individuais por loja (00 a 11/15) com valor raw colorido (verde/laranja/vermelho)
- Acima dos chips: valor geral com mini barra de progresso
- Largura minima 380px para acomodar 13 lojas em uma linha

### Sub-totais
- Removidos chips; voltaram a usar AtingBar simples

### Backend
- Query 11 atualizada para retornar `dias_estoque` por (codgrp, codloja) alem do NS
- Campo `diasPorLoja` adicionado em `compradoresGrupos`
- Mapa `diasLojasDetalheGrupoMap` criado para alimentar as linhas de grupo

### Frontend
- Novo componente `DiasLojaChips` analogo ao `NsLojaChips`
- Sub-totais revertidos para `AtingBar` conforme solicitado