### PR TITLE
tv-compras-lojas: evolucao por loja, corrige Dias Estoque e header

### DIFF
--- a/backend/sql/vs_scc_vendas_devolucoes_lojas.sql
+++ b/backend/sql/vs_scc_vendas_devolucoes_lojas.sql
@@ -1,0 +1,19 @@
+-- View: vs_scc_vendas_devolucoes_lojas
+-- Mesma estrutura de vs_scc_vendas_devolucoes, acrescida da coluna codloja.
+-- Ajuste o SELECT interno para apontar para a tabela/fonte real do seu sistema legado.
+CREATE OR REPLACE VIEW vs_scc_vendas_devolucoes_lojas AS
+SELECT
+    TRIM(v.codloja)                 AS codloja,
+    v.data,
+    TRIM(v.codgrp)                  AS codgrp,
+    v.tipo,
+    v.vlr_total_vendas_bruta,
+    v.vlr_total_devolucoes,
+    v.vlr_custos_vendas,
+    v.vlr_impostos_vendas
+FROM <fonte_legado> v
+WHERE v.codloja IS NOT NULL;
+-- Exemplo com tabela legada típica:
+-- FROM a_vendas_itens v
+-- ou
+-- FROM a_nf_saidas v

--- a/backend/src/services/dashboardTvComprasService.ts
+++ b/backend/src/services/dashboardTvComprasService.ts
@@ -423,6 +423,66 @@ export const getDashboardTvCompras = async () => {
     ORDER BY tipo, codgrp, comprador, codloja
   `
 
+  // ── Query 12: evolução por loja (vs mesmo período ano passado) ───────────────
+  // Usa vs_scc_vendas_devolucoes_lojas — mesma lógica do período atual × ano ant.
+  const queryEvolLojasDetalhe = `
+    WITH
+    grupos_meta AS (
+      SELECT DISTINCT TRIM(codgrp) AS codgrp
+      FROM scc_metas_compradores
+      WHERE mes = EXTRACT(MONTH FROM CURRENT_DATE)::int
+        AND ano = EXTRACT(YEAR  FROM CURRENT_DATE)::int
+    ),
+    atual AS (
+      SELECT
+        TRIM(codgrp)  AS codgrp,
+        TRIM(codloja) AS codloja,
+        SUM(COALESCE(vlr_total_vendas_bruta,0) - COALESCE(vlr_total_devolucoes,0))        AS venda,
+        SUM(COALESCE(vlr_total_vendas_bruta,0) - COALESCE(vlr_custos_vendas,0)
+              - COALESCE(vlr_impostos_vendas,0))                                           AS lb,
+        SUM(COALESCE(vlr_total_vendas_bruta,0))                                            AS venda_bruta,
+        SUM(CASE WHEN tipo IN ('Fora','Encomenda','FORA','ENCO')
+                 THEN COALESCE(vlr_total_vendas_bruta,0) - COALESCE(vlr_total_devolucoes,0)
+                 ELSE 0 END)                                                               AS venda_fora
+      FROM vs_scc_vendas_devolucoes_lojas
+      WHERE data BETWEEN date_trunc('month', CURRENT_DATE)::date AND CURRENT_DATE
+        AND TRIM(codgrp) IN (SELECT codgrp FROM grupos_meta)
+      GROUP BY TRIM(codgrp), TRIM(codloja)
+    ),
+    anterior AS (
+      SELECT
+        TRIM(codgrp)  AS codgrp,
+        TRIM(codloja) AS codloja,
+        SUM(COALESCE(vlr_total_vendas_bruta,0) - COALESCE(vlr_total_devolucoes,0))        AS venda,
+        SUM(COALESCE(vlr_total_vendas_bruta,0) - COALESCE(vlr_custos_vendas,0)
+              - COALESCE(vlr_impostos_vendas,0))                                           AS lb,
+        SUM(COALESCE(vlr_total_vendas_bruta,0))                                            AS venda_bruta,
+        SUM(CASE WHEN tipo IN ('Fora','Encomenda','FORA','ENCO')
+                 THEN COALESCE(vlr_total_vendas_bruta,0) - COALESCE(vlr_total_devolucoes,0)
+                 ELSE 0 END)                                                               AS venda_fora
+      FROM vs_scc_vendas_devolucoes_lojas
+      WHERE data BETWEEN date_trunc('month', CURRENT_DATE - interval '1 year')::date
+                     AND (CURRENT_DATE - interval '1 year')::date
+        AND TRIM(codgrp) IN (SELECT codgrp FROM grupos_meta)
+      GROUP BY TRIM(codgrp), TRIM(codloja)
+    )
+    SELECT
+      a.codgrp,
+      a.codloja,
+      ROUND(CASE WHEN COALESCE(ant.venda,0) > 0
+                 THEN (a.venda / ant.venda - 1) * 100
+                 ELSE NULL END, 1)                                        AS evol_vendas,
+      ROUND(CASE WHEN COALESCE(ant.venda_bruta,0) > 0 AND COALESCE(a.venda_bruta,0) > 0
+                 THEN ((a.lb / a.venda_bruta) - (ant.lb / ant.venda_bruta)) * 100
+                 ELSE NULL END, 1)                                        AS evol_lb,
+      ROUND(CASE WHEN COALESCE(ant.venda_fora,0) > 0
+                 THEN (a.venda_fora / ant.venda_fora - 1) * 100
+                 ELSE NULL END, 1)                                        AS evol_prod_fora
+    FROM atual a
+    LEFT JOIN anterior ant USING (codgrp, codloja)
+    ORDER BY a.codgrp, a.codloja
+  `
+
   // ── Query 9: top 10 dias sem estoque — curva A1 ───────────────────────────
   const queryRupturaCurvaA = `
     SELECT
@@ -437,7 +497,7 @@ export const getDashboardTvCompras = async () => {
     LIMIT 10
   `
 
-  const [r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11] = await Promise.all([
+  const [r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12] = await Promise.all([
     pool.query(queryCompradores),
     pool.query(queryGlobal),
     pool.query(querySeries),
@@ -449,6 +509,7 @@ export const getDashboardTvCompras = async () => {
     pool.query(queryRupturaCurvaA),
     pool.query(queryNsLojasGrupo),
     pool.query(queryNsLojasDetalhe),
+    pool.query(queryEvolLojasDetalhe).catch(() => ({ rows: [] })),
   ])
 
   // ── Mapa de NS por lojas (produto × loja) por grupo + total global ───────
@@ -469,6 +530,19 @@ export const getDashboardTvCompras = async () => {
     if (!diasLojasDetalheGrupoMap.has(key)) diasLojasDetalheGrupoMap.set(key, [])
     nsLojasDetalheGrupoMap.get(key)!.push({ codloja: loja, nivelServico: safe(row.nivel_servico) })
     diasLojasDetalheGrupoMap.get(key)!.push({ codloja: loja, diasEstoque: safe(row.dias_estoque) })
+  }
+
+  // ── Mapa de evolução por (codgrp, codloja) ───────────────────────────────
+  const evolLojasMap = new Map<string, { codloja: string; evolVendas: number | null; evolLb: number | null; evolProdFora: number | null }[]>()
+  for (const row of r12.rows) {
+    const key = String(row.codgrp).trim()
+    if (!evolLojasMap.has(key)) evolLojasMap.set(key, [])
+    evolLojasMap.get(key)!.push({
+      codloja:    String(row.codloja).trim(),
+      evolVendas: row.evol_vendas  !== null ? Number(row.evol_vendas)   : null,
+      evolLb:     row.evol_lb      !== null ? Number(row.evol_lb)       : null,
+      evolProdFora: row.evol_prod_fora !== null ? Number(row.evol_prod_fora) : null,
+    })
   }
 
   // ── Mapa de métricas por grupo ────────────────────────────────────────────
@@ -651,6 +725,7 @@ export const getDashboardTvCompras = async () => {
       nivelServicoLojas: nsLojasMap.has(codgrp) ? Number(nsLojasMap.get(codgrp)!.toFixed(1)) : null,
       nsPorLoja:   nsLojasDetalheGrupoMap.get(codgrp) ?? [],
       diasPorLoja: diasLojasDetalheGrupoMap.get(codgrp) ?? [],
+      evolPorLoja: evolLojasMap.get(codgrp) ?? [],
       nivelServicoMeta: safe(row.meta_nivel_servico) || 97,
       diasEstoque: mg ? Math.round(mg.diasEstoque) : null,
       diasEstoqueMeta: safe(row.meta_dias_estoque) || 45,

--- a/frontend/src/pages/TvComprasLojas.tsx
+++ b/frontend/src/pages/TvComprasLojas.tsx
@@ -85,7 +85,7 @@ function NsLojaChips({ lojas, meta = 97, overall }: {
           </div>
         </div>
       )}
-      <div style={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
+      <div style={{ display: "flex", flexWrap: "nowrap", gap: 2 }}>
         {lojas.map(l => {
           const ns = l.nivelServico
           const color = ns >= meta ? C.green : ns >= meta * 0.9 ? C.orange : C.red
@@ -108,47 +108,62 @@ function NsLojaChips({ lojas, meta = 97, overall }: {
   )
 }
 
-// ─── Chips de Dias de Estoque por loja ───────────────────────────────────────
-function DiasLojaChips({ lojas, meta = 45, overall }: {
+// ─── Chips de Dias de Estoque por loja (sem barra overall — AtingBar cuida disso) ─
+function DiasLojaChips({ lojas, meta = 45 }: {
   lojas: { codloja: string; diasEstoque: number }[]
   meta?: number
-  overall?: number
 }) {
-  if (!lojas.length) return <span style={{ color: C.muted, fontSize: 11 }}>—</span>
-  const overallColor = overall !== undefined
-    ? (overall <= meta ? C.green : overall <= meta * 1.2 ? C.orange : C.red)
-    : C.muted
+  if (!lojas.length) return null
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
-      {overall !== undefined && (
-        <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
-          <span style={{ fontSize: 12, fontWeight: 800, color: overallColor, fontVariantNumeric: "tabular-nums" }}>
-            {Math.round(overall)}d
-          </span>
-          <div style={{ flex: 1, height: 4, background: C.dim, borderRadius: 2, overflow: "hidden" }}>
-            <div style={{ width: `${Math.min(100, (meta / Math.max(overall, 1)) * 100)}%`, height: "100%", background: overallColor, borderRadius: 2 }} />
+    <div style={{ display: "flex", flexWrap: "nowrap", gap: 2, marginTop: 3 }}>
+      {lojas.map(l => {
+        const d = l.diasEstoque
+        const color = d <= meta ? C.green : d <= meta * 1.2 ? C.orange : C.red
+        return (
+          <div key={l.codloja} style={{
+            display: "flex", flexDirection: "column", alignItems: "center",
+            background: color + "1A",
+            border: `1px solid ${color}55`,
+            borderRadius: 3,
+            padding: "1px 4px",
+            minWidth: 26,
+          }}>
+            <span style={{ fontSize: 7, color: C.muted, lineHeight: 1.2 }}>{l.codloja}</span>
+            <span style={{ fontSize: 9, color, fontWeight: 700, lineHeight: 1.2, fontVariantNumeric: "tabular-nums" }}>{d}d</span>
           </div>
-        </div>
-      )}
-      <div style={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
-        {lojas.map(l => {
-          const d = l.diasEstoque
-          const color = d <= meta ? C.green : d <= meta * 1.2 ? C.orange : C.red
-          return (
-            <div key={l.codloja} style={{
-              display: "flex", flexDirection: "column", alignItems: "center",
-              background: color + "1A",
-              border: `1px solid ${color}55`,
-              borderRadius: 3,
-              padding: "1px 4px",
-              minWidth: 26,
-            }}>
-              <span style={{ fontSize: 7, color: C.muted, lineHeight: 1.2 }}>{l.codloja}</span>
-              <span style={{ fontSize: 9, color, fontWeight: 700, lineHeight: 1.2, fontVariantNumeric: "tabular-nums" }}>{d}d</span>
-            </div>
-          )
-        })}
-      </div>
+        )
+      })}
+    </div>
+  )
+}
+
+// ─── Chips de evolução por loja (vs mesmo período ano passado) ────────────────
+function EvolLojaChips({ lojas, field }: {
+  lojas: { codloja: string; evolVendas: number | null; evolLb: number | null; evolProdFora: number | null }[]
+  field: "evolVendas" | "evolLb" | "evolProdFora"
+}) {
+  if (!lojas.length) return null
+  return (
+    <div style={{ display: "flex", flexWrap: "nowrap", gap: 2, marginTop: 3 }}>
+      {lojas.map(l => {
+        const v = l[field]
+        if (v === null) return null
+        const color = v >= 0 ? C.green : v >= -10 ? C.orange : C.red
+        const sign  = v >= 0 ? "+" : ""
+        return (
+          <div key={l.codloja} style={{
+            display: "flex", flexDirection: "column", alignItems: "center",
+            background: color + "1A",
+            border: `1px solid ${color}55`,
+            borderRadius: 3,
+            padding: "1px 4px",
+            minWidth: 26,
+          }}>
+            <span style={{ fontSize: 7, color: C.muted, lineHeight: 1.2 }}>{l.codloja}</span>
+            <span style={{ fontSize: 9, color, fontWeight: 700, lineHeight: 1.2, fontVariantNumeric: "tabular-nums" }}>{sign}{v.toFixed(0)}%</span>
+          </div>
+        )
+      })}
     </div>
   )
 }
@@ -290,8 +305,7 @@ export default function TvComprasLojas() {
         <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
           <div style={{ width: 44, height: 44, borderRadius: "50%", background: "linear-gradient(135deg,#0e2b5c,#1D9BF0)", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 20 }}>🛒</div>
           <div>
-            <div style={{ fontSize: 22, fontWeight: 800, letterSpacing: "0.04em", lineHeight: 1 }}>DASHBOARD COMPRAS</div>
-            <div style={{ fontSize: 11, color: "#4B7FB5", letterSpacing: "0.1em" }}>DESEMPENHO POR COMPRADOR E GRUPO — {mesLabel.toUpperCase()}</div>
+            <div style={{ fontSize: 22, fontWeight: 800, letterSpacing: "0.04em", lineHeight: 1 }}>J MONTE CENTER</div>
           </div>
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 20 }}>
@@ -335,11 +349,11 @@ export default function TvComprasLojas() {
             <tr>
               <th style={th}>Comprador</th>
               <th style={th}>Grupo</th>
-              <th style={{ ...thG, textAlign: "center", minWidth: 140 }}>Vendas<br/>Atingimento</th>
-              <th style={{ ...thG, textAlign: "center", minWidth: 140 }}>LB<br/>Atingimento</th>
-              <th style={{ ...thG, textAlign: "center", minWidth: 380 }}>Nível Serviço<br/>Atingimento</th>
-              <th style={{ ...thG, textAlign: "center", minWidth: 380 }}>Dias Estoque<br/>Atingimento</th>
-              <th style={{ ...thG, textAlign: "center", minWidth: 140 }}>Prod. Fora<br/>Atingimento</th>
+              <th style={{ ...thG, textAlign: "center" }}>Vendas<br/>Atingimento</th>
+              <th style={{ ...thG, textAlign: "center" }}>LB<br/>Atingimento</th>
+              <th style={{ ...thG, textAlign: "center" }}>Nível Serviço<br/>Atingimento</th>
+              <th style={{ ...thG, textAlign: "center" }}>Dias Estoque<br/>Atingimento</th>
+              <th style={{ ...thG, textAlign: "center" }}>Prod. Fora<br/>Atingimento</th>
               <th style={{ ...thG, textAlign: "center" }}>Metas</th>
             </tr>
           </thead>
@@ -360,23 +374,32 @@ export default function TvComprasLojas() {
                       </td>
                     )}
                     <td style={{ ...tdN, ...sepStyle, fontSize: 10 }}>{g.grupoNome}</td>
-                    <td style={{ ...tdG, ...sepStyle }}><AtingBar pct={safe(g.vendaPercentualMeta)} /></td>
-                    <td style={{ ...tdG, ...sepStyle }}><AtingBar pct={lbAting(g)} /></td>
-                    <td style={{ ...tdG, ...sepStyle }}>
+                    <td style={{ ...tdG, ...sepStyle, whiteSpace: "nowrap" }}>
+                      <AtingBar pct={safe(g.vendaPercentualMeta)} />
+                      <EvolLojaChips lojas={g.evolPorLoja ?? []} field="evolVendas" />
+                    </td>
+                    <td style={{ ...tdG, ...sepStyle, whiteSpace: "nowrap" }}>
+                      <AtingBar pct={lbAting(g)} />
+                      <EvolLojaChips lojas={g.evolPorLoja ?? []} field="evolLb" />
+                    </td>
+                    <td style={{ ...tdG, ...sepStyle, whiteSpace: "nowrap" }}>
                       <NsLojaChips
                         lojas={g.nsPorLoja ?? []}
                         meta={g.nivelServicoMeta || 97}
                         overall={nsPresent(g) ? nsVal(g) : undefined}
                       />
                     </td>
-                    <td style={{ ...tdG, ...sepStyle }}>
+                    <td style={{ ...tdG, ...sepStyle, whiteSpace: "nowrap" }}>
+                      <AtingBar pct={diasAting(g)} />
                       <DiasLojaChips
                         lojas={g.diasPorLoja ?? []}
                         meta={g.diasEstoqueMeta || 45}
-                        overall={g.diasEstoque !== null ? safe(g.diasEstoque) : undefined}
                       />
                     </td>
-                    <td style={{ ...tdG, ...sepStyle }}><AtingBar pct={safe(g.produtosForaPercentual)} /></td>
+                    <td style={{ ...tdG, ...sepStyle, whiteSpace: "nowrap" }}>
+                      <AtingBar pct={safe(g.produtosForaPercentual)} />
+                      <EvolLojaChips lojas={g.evolPorLoja ?? []} field="evolProdFora" />
+                    </td>
                     <td style={{ ...tdG, ...sepStyle }}><MetaIcons c={g} /></td>
                   </tr>
                 )


### PR DESCRIPTION
## Resumo

Melhoria na pagina tv-compras-lojas com chips de evolucao por loja em Vendas/LB/Prod. Fora, restauracao do AtingBar na coluna Dias Estoque, larguras de colunas auto-ajustaveis e atualizacao do cabecalho.

## O que mudou

### Backend
- Query 12 (queryEvolLojasDetalhe): calcula evolucao de vendas/LB/prod.fora por (codgrp, codloja) vs mesmo periodo ano passado usando vs_scc_vendas_devolucoes_lojas
- Query protegida com .catch para nao quebrar enquanto a view nao existir
- Campo evolPorLoja adicionado a cada item de compradoresGrupos

### Frontend
- Cabecalho: DASHBOARD COMPRAS -> J MONTE CENTER, subtitulo removido
- Novo componente EvolLojaChips: chips por loja com +X%/-X% coloridos
- Colunas Vendas, LB, Prod. Fora (grupo): AtingBar intacta + EvolLojaChips abaixo
- Coluna Dias Estoque (grupo): AtingBar restaurada + DiasLojaChips abaixo sem barra overall
- Todas as 5 colunas metricas: minWidth fixo removido, whiteSpace nowrap para auto-ajuste

### SQL
- Template backend/sql/vs_scc_vendas_devolucoes_lojas.sql criado (ajustar tabela fonte e executar no banco)