### PR TITLE
tv-compras-lojas: chips evolucao com 12 lojas e logica -100/+100/dash

### DIFF
--- a/backend/src/services/dashboardTvComprasService.ts
+++ b/backend/src/services/dashboardTvComprasService.ts
@@ -424,7 +424,13 @@ export const getDashboardTvCompras = async () => {
   `
 
   // ── Query 12: evolução por loja (vs mesmo período ano passado) ───────────────
-  // Usa vs_scc_vendas_devolucoes_lojas — mesma lógica do período atual × ano ant.
+  // Sempre retorna as 12 lojas (00–11) × cada codgrp com meta.
+  // Regras por métrica de vendas/prod.fora:
+  //   atual=0  e ant=0  → NULL  (sem venda em nenhum ano → exibe "–")
+  //   atual>0  e ant=0  → +100% (nova loja / primeiro mês)
+  //   atual=0  e ant>0  → -100% (loja parou de vender)
+  //   ambos>0           → evolução normal
+  // Para LB (comparação de %) → NULL quando falta qualquer lado (sem sentido ±100%)
   const queryEvolLojasDetalhe = `
     WITH
     grupos_meta AS (
@@ -432,6 +438,15 @@ export const getDashboardTvCompras = async () => {
       FROM scc_metas_compradores
       WHERE mes = EXTRACT(MONTH FROM CURRENT_DATE)::int
         AND ano = EXTRACT(YEAR  FROM CURRENT_DATE)::int
+    ),
+    lojas AS (
+      SELECT lpad(gs::text, 2, '0') AS codloja
+      FROM generate_series(0, 11) gs
+    ),
+    base AS (
+      SELECT gm.codgrp, l.codloja
+      FROM grupos_meta gm
+      CROSS JOIN lojas l
     ),
     atual AS (
       SELECT
@@ -467,20 +482,32 @@ export const getDashboardTvCompras = async () => {
       GROUP BY TRIM(codgrp), TRIM(codloja)
     )
     SELECT
-      a.codgrp,
-      a.codloja,
-      ROUND(CASE WHEN COALESCE(ant.venda,0) > 0
-                 THEN (a.venda / ant.venda - 1) * 100
-                 ELSE NULL END, 1)                                        AS evol_vendas,
-      ROUND(CASE WHEN COALESCE(ant.venda_bruta,0) > 0 AND COALESCE(a.venda_bruta,0) > 0
-                 THEN ((a.lb / a.venda_bruta) - (ant.lb / ant.venda_bruta)) * 100
-                 ELSE NULL END, 1)                                        AS evol_lb,
-      ROUND(CASE WHEN COALESCE(ant.venda_fora,0) > 0
-                 THEN (a.venda_fora / ant.venda_fora - 1) * 100
-                 ELSE NULL END, 1)                                        AS evol_prod_fora
-    FROM atual a
+      b.codgrp,
+      b.codloja,
+      -- Vendas: NULL = sem dados em nenhum ano, ±100 quando só um lado tem dados
+      ROUND(CASE
+        WHEN COALESCE(a.venda,0) = 0 AND COALESCE(ant.venda,0) = 0 THEN NULL
+        WHEN COALESCE(ant.venda,0) = 0                              THEN  100.0
+        WHEN COALESCE(a.venda,0)   = 0                              THEN -100.0
+        ELSE (a.venda / ant.venda - 1) * 100
+      END, 1) AS evol_vendas,
+      -- LB% (pp): NULL quando falta qualquer lado (±100 não faz sentido para %)
+      ROUND(CASE
+        WHEN COALESCE(a.venda_bruta,0) > 0 AND COALESCE(ant.venda_bruta,0) > 0
+          THEN ((a.lb / a.venda_bruta) - (ant.lb / ant.venda_bruta)) * 100
+        ELSE NULL
+      END, 1) AS evol_lb,
+      -- Prod. Fora: mesma lógica de Vendas
+      ROUND(CASE
+        WHEN COALESCE(a.venda_fora,0) = 0 AND COALESCE(ant.venda_fora,0) = 0 THEN NULL
+        WHEN COALESCE(ant.venda_fora,0) = 0                                   THEN  100.0
+        WHEN COALESCE(a.venda_fora,0)   = 0                                   THEN -100.0
+        ELSE (a.venda_fora / ant.venda_fora - 1) * 100
+      END, 1) AS evol_prod_fora
+    FROM base b
+    LEFT JOIN atual    a   USING (codgrp, codloja)
     LEFT JOIN anterior ant USING (codgrp, codloja)
-    ORDER BY a.codgrp, a.codloja
+    ORDER BY b.codgrp, b.codloja
   `
 
   // ── Query 9: top 10 dias sem estoque — curva A1 ───────────────────────────

--- a/frontend/src/pages/TvComprasLojas.tsx
+++ b/frontend/src/pages/TvComprasLojas.tsx
@@ -137,6 +137,9 @@ function DiasLojaChips({ lojas, meta = 45 }: {
 }
 
 // ─── Chips de evolução por loja (vs mesmo período ano passado) ────────────────
+// v === null → sem venda em nenhum dos dois anos → exibe "–" em muted
+// v === -100 → tinha ano passado, não tem este → vermelho
+// v === +100 → não tinha ano passado, tem este → verde
 function EvolLojaChips({ lojas, field }: {
   lojas: { codloja: string; evolVendas: number | null; evolLb: number | null; evolProdFora: number | null }[]
   field: "evolVendas" | "evolLb" | "evolProdFora"
@@ -146,9 +149,24 @@ function EvolLojaChips({ lojas, field }: {
     <div style={{ display: "flex", flexWrap: "nowrap", gap: 1, marginTop: 2 }}>
       {lojas.map(l => {
         const v = l[field]
-        if (v === null) return null
+        if (v === null) {
+          // sem venda em nenhum dos dois períodos
+          return (
+            <div key={l.codloja} style={{
+              display: "flex", flexDirection: "column", alignItems: "center",
+              background: C.dim + "88",
+              border: `1px solid ${C.border}`,
+              borderRadius: 2,
+              padding: "0px 3px",
+              minWidth: 20,
+            }}>
+              <span style={{ fontSize: 6, color: C.muted, lineHeight: 1.3 }}>{l.codloja}</span>
+              <span style={{ fontSize: 7, color: C.muted, fontWeight: 500, lineHeight: 1.2 }}>–</span>
+            </div>
+          )
+        }
         const color = v >= 0 ? C.green : v >= -10 ? C.orange : C.red
-        const sign  = v >= 0 ? "+" : ""
+        const sign  = v > 0 ? "+" : ""
         return (
           <div key={l.codloja} style={{
             display: "flex", flexDirection: "column", alignItems: "center",


### PR DESCRIPTION
## Resumo

Corrige os chips de evolucao por loja nas colunas Vendas, LB e Prod. Fora para sempre exibir as 12 lojas (00-11), com logica correta para cada combinacao de dados presentes/ausentes.

## Regras implementadas

### Vendas e Prod. Fora
- Sem venda em nenhum dos dois anos -> NULL -> chip cinza com traco (-)
- So ano atual, anterior = 0 -> +100%
- So ano passado, atual = 0 -> -100%
- Ambos > 0 -> evolucao normal

### LB (variacao em pontos percentuais)
- Mantem NULL quando falta qualquer lado (+-100pp nao faz sentido para %)

## Mudancas

### Backend (dashboardTvComprasService.ts)
- Query 12 reescrita com base CROSS JOIN grupos_meta x lojas(00-11)
- Todas as 12 lojas sempre presentes no resultado, mesmo sem vendas
- CASE expressions corrigidos para cada combinacao atual/anterior

### Frontend (TvComprasLojas.tsx)
- EvolLojaChips: v===null exibe chip cinza com traco em vez de suprimir o chip
- Assim todas as 12 lojas aparecem sempre em cada coluna de evolucao