### PR TITLE
fix: libera acesso por IP na configuração de CORS

### DIFF
--- a/backend/src/config/cors.ts
+++ b/backend/src/config/cors.ts
@@ -2,11 +2,18 @@ import cors from "cors"
 
 const isProduction = process.env.NODE_ENV === "production"
 
+const devOrigins = [
+    "http://localhost:8600",
+    "http://localhost:3000",
+    "http://10.5.59.85:8600",
+    "http://10.5.59.85:3000",
+]
+
 const allowedOrigins = process.env.FRONTEND_URL
     ? process.env.FRONTEND_URL.split(",").map((o) => o.trim()).filter(Boolean)
     : isProduction
         ? [] // em produção, exige FRONTEND_URL explícito
-        : ["http://localhost:8600", "http://localhost:3000"]
+        : devOrigins
 
 if (isProduction && allowedOrigins.length === 0) {
     throw new Error("FRONTEND_URL não definido em produção. Defina a variável de ambiente FRONTEND_URL.")


### PR DESCRIPTION
Login falhava silenciosamente com erro de "senha inválida" ao acessar via IP (10.5.59.85 ou 172.20.33.15) porque o CORS do backend só aceitava requisições de localhost. O browser bloqueava a resposta e o frontend interpretava o erro de rede como credenciais incorretas.

Adiciona o IP de desenvolvimento (10.5.59.85) aos origins permitidos por padrão. Para produção (172.20.33.15), o FRONTEND_URL deve ser definido no .env do servidor.