### PR TITLE
tv-compras-lojas: ordena compradores por faturamento decrescente

### DIFF
--- a/frontend/src/pages/TvComprasLojas.tsx
+++ b/frontend/src/pages/TvComprasLojas.tsx
@@ -272,7 +272,7 @@ export default function TvComprasLojas() {
       comprador,
       grupos,
       sub: compMap.get(comprador) ?? null,
-    }))
+    })).sort((a, b) => safe(b.sub?.vendaRealizado) - safe(a.sub?.vendaRealizado))
   })()
 
   // Converte métricas para % de atingimento


### PR DESCRIPTION
Substitui ordem alfabética pela ordem de maior para menor faturamento (vendaRealizado acumulado até o dia corrido do mês).