### PR TITLE
DRE F360: corrige totalizadores em linhas com múltiplas subdescrições

### DIFF
--- a/frontend/src/pages/DreF360.tsx
+++ b/frontend/src/pages/DreF360.tsx
@@ -49,7 +49,16 @@ const somarCampo = (
   items: DreF360Registro[],
   campo: "realizado" | "orcado",
 ): number | null => {
-  const nums = items.map((r) => r[campo]).filter((v): v is number => v !== null)
+  // Converte cada valor para número antes de somar — o PostgreSQL retorna
+  // colunas numeric como string, e (0 + "100" + "200") resultaria em "0100200".
+  const nums = items
+    .map((r) => {
+      const v = r[campo]
+      if (v === null || v === undefined) return null
+      const n = Number(v)
+      return Number.isNaN(n) ? null : n
+    })
+    .filter((v): v is number => v !== null)
   return nums.length > 0 ? nums.reduce((a, b) => a + b, 0) : null
 }
 


### PR DESCRIPTION
O PostgreSQL retorna colunas numeric como string. O reduce anterior iniciava em 0 (número) e somava strings, resultando em concatenação ("01000.00500.00") que converte para NaN — exibindo vazio nas linhas de resumo com 2 ou mais itens.

Solução: converter cada valor com Number() antes do reduce, garantindo soma aritmética independente de o valor chegar como string ou número.