### PR TITLE
Compradores: adiciona página Desempenho com histórico por mês/ano

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -11,6 +11,7 @@ import dreRoutes from "./routes/dreRoutes"
 import dreF360Routes from "./routes/dreF360Routes"
 import helpDeskRoutes from "./routes/helpDeskRoutes"
 import compradoresRoutes from "./routes/compradoresRoutes"
+import compradoresHistoricoRoutes from "./routes/compradoresHistoricoRoutes"
 import dashboardTvComprasRoutes from "./routes/dashboardTvComprasRoutes"
 import { corsMiddleware } from "./config/cors"
 
@@ -36,6 +37,7 @@ app.use("/api/dre", dreRoutes)
 app.use("/api/dre-f360", dreF360Routes)
 app.use("/api/help-desk", helpDeskRoutes)
 app.use("/api", compradoresRoutes)
+app.use("/api/compradores", compradoresHistoricoRoutes)
 app.use("/", dashboardTvComprasRoutes)
 
 // Rota de teste para verificar se o servidor está funcionando

--- a/backend/src/controllers/compradoresHistoricoController.ts
+++ b/backend/src/controllers/compradoresHistoricoController.ts
@@ -1,0 +1,19 @@
+import type { Request, Response } from "express"
+import { getDashboardHistorico } from "../services/compradoresHistoricoService"
+
+export const getCompradoresHistorico = async (req: Request, res: Response) => {
+  try {
+    const ano = req.query.ano ? Number(req.query.ano) : null
+    const mes = req.query.mes ? Number(req.query.mes) : null
+
+    if (!ano || !mes || Number.isNaN(ano) || Number.isNaN(mes) || mes < 1 || mes > 12) {
+      return res.status(400).json({ message: "Parâmetros ano e mes são obrigatórios (ex: ?ano=2025&mes=4)" })
+    }
+
+    const data = await getDashboardHistorico(ano, mes)
+    return res.json(data)
+  } catch (error) {
+    console.error("Erro ao buscar histórico de compradores:", error)
+    return res.status(500).json({ message: "Erro ao buscar histórico de compradores." })
+  }
+}

--- a/backend/src/routes/compradoresHistoricoRoutes.ts
+++ b/backend/src/routes/compradoresHistoricoRoutes.ts
@@ -1,0 +1,10 @@
+import { Router } from "express"
+import { getCompradoresHistorico } from "../controllers/compradoresHistoricoController"
+import { verificarAutenticacao, verificarPermissao } from "../middlewares/authMiddleware"
+
+const router = Router()
+
+router.use(verificarAutenticacao)
+router.get("/historico", verificarPermissao("compradores", "visualizar"), getCompradoresHistorico)
+
+export default router

--- a/backend/src/services/compradoresHistoricoService.ts
+++ b/backend/src/services/compradoresHistoricoService.ts
@@ -1,0 +1,568 @@
+import pool from "../config/database"
+
+const safe = (v: unknown): number => (Number.isFinite(Number(v)) ? Number(v) : 0)
+
+/**
+ * Retorna o mesmo shape que getDashboardTvCompras(), mas para um mês/ano
+ * histórico escolhido. Todas as referências a CURRENT_DATE são substituídas
+ * pelo último dia do mês solicitado ($1::date), de forma que dias_decorridos
+ * = total_dias (mês completo).
+ */
+export const getDashboardHistorico = async (ano: number, mes: number) => {
+  const diasNoMes = new Date(ano, mes, 0).getDate()
+  const dataFim = `${ano}-${String(mes).padStart(2, "0")}-${String(diasNoMes).padStart(2, "0")}`
+  const p = [dataFim] // $1 = último dia do mês solicitado
+
+  // ── Query 1: compradores ────────────────────────────────────────────────
+  const queryCompradores = `
+    WITH
+    grupos_meta AS (
+      SELECT DISTINCT TRIM(codgrp) AS codgrp
+      FROM scc_metas_compradores
+      WHERE mes = EXTRACT(MONTH FROM $1::date)::int
+        AND ano = EXTRACT(YEAR  FROM $1::date)::int
+    ),
+    dias_mes AS (
+      SELECT
+        EXTRACT(DAY FROM $1::date)::int AS dias_decorridos,
+        EXTRACT(DAY FROM (date_trunc('month', $1::date)
+                          + interval '1 month' - interval '1 day')::date)::int AS total_dias
+    ),
+    grupos_ativos AS (
+      SELECT TRIM(cg.codgrp) AS codgrp, c.nome AS comprador, cg.comprador_id
+      FROM scc_comprador_grupo cg
+      JOIN scc_compradores c ON c.id = cg.comprador_id
+      WHERE cg.dt_fim IS NULL
+        AND TRIM(cg.codgrp) IN (SELECT codgrp FROM grupos_meta)
+    ),
+    nomes_grupo AS (
+      SELECT TRIM(codgrp) AS codgrp, MIN(grupo) AS grupo
+      FROM vs_scc_dgrupos
+      GROUP BY TRIM(codgrp)
+    ),
+    vendas_atual AS (
+      SELECT
+        TRIM(codgrp) AS codgrp,
+        SUM(COALESCE(vlr_total_vendas_bruta, 0) - COALESCE(vlr_total_devolucoes, 0))   AS venda,
+        SUM(COALESCE(vlr_total_vendas_bruta, 0))                                         AS venda_bruta,
+        SUM(COALESCE(vlr_total_vendas_bruta, 0)
+          - COALESCE(vlr_custos_vendas, 0)
+          - COALESCE(vlr_impostos_vendas, 0))                                            AS lb_valor,
+        SUM(CASE WHEN tipo IN ('Fora','Encomenda')
+                 THEN COALESCE(vlr_total_vendas_bruta, 0) - COALESCE(vlr_total_devolucoes, 0)
+                 ELSE 0 END)                                                             AS venda_fora
+      FROM vs_scc_vendas_devolucoes
+      WHERE data BETWEEN date_trunc('month', $1::date)::date AND $1::date
+        AND TRIM(codgrp) IN (SELECT codgrp FROM grupos_meta)
+      GROUP BY TRIM(codgrp)
+    ),
+    vendas_ano_passado AS (
+      SELECT
+        TRIM(codgrp) AS codgrp,
+        SUM(COALESCE(vlr_total_vendas_bruta, 0) - COALESCE(vlr_total_devolucoes, 0)) AS venda
+      FROM vs_scc_vendas_devolucoes
+      WHERE data BETWEEN date_trunc('month', $1::date - interval '1 year')::date
+                     AND ($1::date - interval '1 year')::date
+        AND TRIM(codgrp) IN (SELECT codgrp FROM grupos_meta)
+      GROUP BY TRIM(codgrp)
+    )
+    SELECT
+      ga.comprador,
+      ga.codgrp,
+      COALESCE(ng.grupo, ga.codgrp)  AS grupo_nome,
+      COALESCE(va.venda, 0)          AS venda_realizado,
+      COALESCE(va.venda_bruta, 0)    AS venda_bruta,
+      COALESCE(va.lb_valor, 0)       AS lb_realizado,
+      COALESCE(va.venda_fora, 0)     AS venda_fora_realizado,
+      COALESCE(vap.venda, 0)         AS venda_ano_passado,
+      COALESCE(ROUND(m.meta_vendas        * dm.dias_decorridos::numeric / NULLIF(dm.total_dias, 0), 0), 0) AS meta_vendas_ajustada,
+      COALESCE(m.meta_lb, 0)         AS meta_lb,
+      COALESCE(ROUND(m.meta_produtos_fora * dm.dias_decorridos::numeric / NULLIF(dm.total_dias, 0), 0), 0) AS meta_produtos_fora_ajustada,
+      COALESCE(m.meta_nivel_servico, 97) AS meta_nivel_servico,
+      COALESCE(m.meta_dias_estoque, 45)  AS meta_dias_estoque
+    FROM grupos_ativos ga
+    CROSS JOIN dias_mes dm
+    LEFT JOIN nomes_grupo ng ON ng.codgrp = ga.codgrp
+    LEFT JOIN scc_metas_compradores m
+      ON  m.comprador_id = ga.comprador_id
+      AND TRIM(m.codgrp) = ga.codgrp
+      AND m.mes = EXTRACT(MONTH FROM $1::date)::int
+      AND m.ano = EXTRACT(YEAR  FROM $1::date)::int
+    LEFT JOIN vendas_atual       va  ON va.codgrp = ga.codgrp
+    LEFT JOIN vendas_ano_passado vap ON vap.codgrp = ga.codgrp
+    ORDER BY ga.comprador, ga.codgrp
+  `
+
+  // ── Query 2: KPIs globais ────────────────────────────────────────────────
+  const queryGlobal = `
+    WITH
+    grupos_meta AS (
+      SELECT DISTINCT TRIM(codgrp) AS codgrp
+      FROM scc_metas_compradores
+      WHERE mes = EXTRACT(MONTH FROM $1::date)::int
+        AND ano = EXTRACT(YEAR  FROM $1::date)::int
+    ),
+    dias_mes AS (
+      SELECT
+        EXTRACT(DAY FROM $1::date)::int AS dias_decorridos,
+        EXTRACT(DAY FROM (date_trunc('month', $1::date)
+                          + interval '1 month' - interval '1 day')::date)::int AS total_dias
+    ),
+    va AS (
+      SELECT
+        COALESCE(SUM(COALESCE(vlr_total_vendas_bruta,0) - COALESCE(vlr_total_devolucoes,0)), 0) AS venda,
+        COALESCE(SUM(COALESCE(vlr_total_vendas_bruta,0)), 0)                                     AS venda_bruta,
+        COALESCE(SUM(COALESCE(vlr_total_vendas_bruta,0)
+                   - COALESCE(vlr_custos_vendas,0)
+                   - COALESCE(vlr_impostos_vendas,0)), 0)                                        AS lb_valor,
+        COALESCE(SUM(CASE WHEN tipo IN ('Fora','Encomenda')
+                     THEN COALESCE(vlr_total_vendas_bruta,0) - COALESCE(vlr_total_devolucoes,0)
+                     ELSE 0 END), 0)                                                             AS venda_fora
+      FROM vs_scc_vendas_devolucoes
+      WHERE data BETWEEN date_trunc('month', $1::date)::date AND $1::date
+        AND TRIM(codgrp) IN (SELECT codgrp FROM grupos_meta)
+    ),
+    vap AS (
+      SELECT
+        COALESCE(SUM(COALESCE(vlr_total_vendas_bruta,0) - COALESCE(vlr_total_devolucoes,0)), 0) AS venda,
+        COALESCE(SUM(COALESCE(vlr_total_vendas_bruta,0)), 0)                                     AS venda_bruta,
+        COALESCE(SUM(COALESCE(vlr_total_vendas_bruta,0)
+                   - COALESCE(vlr_custos_vendas,0)
+                   - COALESCE(vlr_impostos_vendas,0)), 0)                                        AS lb_valor
+      FROM vs_scc_vendas_devolucoes
+      WHERE data BETWEEN date_trunc('month', $1::date - interval '1 year')::date
+                     AND ($1::date - interval '1 year')::date
+        AND TRIM(codgrp) IN (SELECT codgrp FROM grupos_meta)
+    ),
+    metas AS (
+      SELECT
+        COALESCE(SUM(meta_vendas), 0)         AS meta_vendas,
+        COALESCE(SUM(meta_produtos_fora), 0)  AS meta_produtos_fora,
+        COALESCE(AVG(meta_lb), 0)             AS meta_lb_media,
+        COALESCE(AVG(meta_dias_estoque), 45)  AS meta_dias_estoque_media,
+        COALESCE(AVG(meta_nivel_servico), 98) AS meta_nivel_servico_media
+      FROM scc_metas_compradores
+      WHERE mes = EXTRACT(MONTH FROM $1::date)::int
+        AND ano = EXTRACT(YEAR  FROM $1::date)::int
+        AND TRIM(codgrp) IN (SELECT codgrp FROM grupos_meta)
+    ),
+    ns AS (
+      SELECT
+        ROUND(COUNT(CASE WHEN facing > 0 AND saldoestoque > 0 THEN 1 END)::numeric
+              / NULLIF(COUNT(CASE WHEN facing > 0 THEN 1 END), 0) * 100, 1) AS nivel_servico
+      FROM vs_scc_estoque_media_facing
+      WHERE codgrp IN (SELECT codgrp FROM grupos_meta)
+    ),
+    dias_est AS (
+      SELECT
+        ROUND(SUM(CASE WHEN mediadia > 0 THEN saldoestoque ELSE 0 END)
+              / NULLIF(SUM(CASE WHEN mediadia > 0 THEN mediadia ELSE 0 END), 0), 0) AS dias_estoque
+      FROM vs_scc_estoque_media_facing
+      WHERE codgrp IN (SELECT codgrp FROM grupos_meta)
+    )
+    SELECT
+      va.venda               AS vendas_valor,
+      va.venda_bruta,
+      va.lb_valor,
+      va.venda_fora          AS produtos_fora_valor,
+      vap.venda              AS vendas_ano_passado,
+      ns.nivel_servico,
+      dias_est.dias_estoque,
+      metas.meta_vendas,
+      metas.meta_produtos_fora,
+      metas.meta_lb_media,
+      metas.meta_dias_estoque_media,
+      metas.meta_nivel_servico_media,
+      dm.dias_decorridos,
+      dm.total_dias
+    FROM va, vap, metas, ns, dias_est
+    CROSS JOIN dias_mes dm
+  `
+
+  // ── Query 3: NS e dias de estoque por grupo ──────────────────────────────
+  const queryMetricsGrupo = `
+    WITH grupos_meta AS (
+      SELECT DISTINCT TRIM(codgrp) AS codgrp
+      FROM scc_metas_compradores
+      WHERE mes = EXTRACT(MONTH FROM $1::date)::int
+        AND ano = EXTRACT(YEAR  FROM $1::date)::int
+    )
+    SELECT
+      ef.codgrp,
+      ROUND(COUNT(CASE WHEN ef.facing > 0 AND ef.saldoestoque > 0 THEN 1 END)::numeric
+            / NULLIF(COUNT(CASE WHEN ef.facing > 0 THEN 1 END), 0) * 100, 1) AS nivel_servico,
+      ROUND(SUM(CASE WHEN ef.mediadia > 0 THEN ef.saldoestoque ELSE 0 END)
+            / NULLIF(SUM(CASE WHEN ef.mediadia > 0 THEN ef.mediadia ELSE 0 END), 0), 0) AS dias_estoque
+    FROM vs_scc_estoque_media_facing ef
+    WHERE ef.codgrp IN (SELECT codgrp FROM grupos_meta)
+    GROUP BY ef.codgrp
+  `
+
+  // ── Query 4: NS por loja (produto × loja), por grupo + total global ──────
+  const queryNsLojasGrupo = `
+    WITH grupos_meta AS (
+      SELECT DISTINCT TRIM(codgrp) AS codgrp
+      FROM scc_metas_compradores
+      WHERE mes = EXTRACT(MONTH FROM $1::date)::int
+        AND ano = EXTRACT(YEAR  FROM $1::date)::int
+    )
+    SELECT
+      TRIM(ef.codgrp) AS codgrp,
+      ROUND(
+        COUNT(CASE WHEN ef.facing > 0 AND ef.saldoestoque > 0 THEN 1 END)::numeric
+        / NULLIF(COUNT(CASE WHEN ef.facing > 0 THEN 1 END), 0) * 100, 1
+      ) AS nivel_servico_lojas
+    FROM vs_scc_estoque_media_facing_lojas ef
+    WHERE TRIM(ef.codgrp) IN (SELECT codgrp FROM grupos_meta)
+    GROUP BY TRIM(ef.codgrp)
+    UNION ALL
+    SELECT
+      '__TOTAL__' AS codgrp,
+      ROUND(
+        COUNT(CASE WHEN ef.facing > 0 AND ef.saldoestoque > 0 THEN 1 END)::numeric
+        / NULLIF(COUNT(CASE WHEN ef.facing > 0 THEN 1 END), 0) * 100, 1
+      ) AS nivel_servico_lojas
+    FROM vs_scc_estoque_media_facing_lojas ef
+    WHERE TRIM(ef.codgrp) IN (SELECT codgrp FROM grupos_meta)
+  `
+
+  // ── Query 5: NS e dias por loja, detalhado por grupo e por comprador ─────
+  const queryNsLojasDetalhe = `
+    WITH
+    grupos_meta AS (
+      SELECT DISTINCT TRIM(codgrp) AS codgrp
+      FROM scc_metas_compradores
+      WHERE mes = EXTRACT(MONTH FROM $1::date)::int
+        AND ano = EXTRACT(YEAR  FROM $1::date)::int
+    ),
+    ga AS (
+      SELECT TRIM(cg.codgrp) AS codgrp, c.nome AS comprador
+      FROM scc_comprador_grupo cg
+      JOIN scc_compradores c ON c.id = cg.comprador_id
+      WHERE cg.dt_fim IS NULL
+        AND TRIM(cg.codgrp) IN (SELECT codgrp FROM grupos_meta)
+    )
+    SELECT
+      'grupo'              AS tipo,
+      TRIM(ef.codgrp)      AS codgrp,
+      NULL::text           AS comprador,
+      TRIM(ef.codloja)     AS codloja,
+      ROUND(
+        COUNT(CASE WHEN ef.facing > 0 AND ef.saldoestoque > 0 THEN 1 END)::numeric
+        / NULLIF(COUNT(CASE WHEN ef.facing > 0 THEN 1 END), 0) * 100, 0
+      ) AS nivel_servico,
+      ROUND(
+        SUM(CASE WHEN ef.mediadia > 0 THEN ef.saldoestoque ELSE 0 END)
+        / NULLIF(SUM(CASE WHEN ef.mediadia > 0 THEN ef.mediadia ELSE 0 END), 0), 0
+      ) AS dias_estoque
+    FROM vs_scc_estoque_media_facing_lojas ef
+    WHERE TRIM(ef.codgrp) IN (SELECT codgrp FROM grupos_meta)
+    GROUP BY TRIM(ef.codgrp), TRIM(ef.codloja)
+    UNION ALL
+    SELECT
+      'comprador'          AS tipo,
+      NULL::text           AS codgrp,
+      ga.comprador,
+      TRIM(ef.codloja)     AS codloja,
+      ROUND(
+        COUNT(CASE WHEN ef.facing > 0 AND ef.saldoestoque > 0 THEN 1 END)::numeric
+        / NULLIF(COUNT(CASE WHEN ef.facing > 0 THEN 1 END), 0) * 100, 0
+      ) AS nivel_servico,
+      ROUND(
+        SUM(CASE WHEN ef.mediadia > 0 THEN ef.saldoestoque ELSE 0 END)
+        / NULLIF(SUM(CASE WHEN ef.mediadia > 0 THEN ef.mediadia ELSE 0 END), 0), 0
+      ) AS dias_estoque
+    FROM vs_scc_estoque_media_facing_lojas ef
+    JOIN ga ON ga.codgrp = TRIM(ef.codgrp)
+    GROUP BY ga.comprador, TRIM(ef.codloja)
+    ORDER BY tipo, codgrp, comprador, codloja
+  `
+
+  // ── Query 6: evolução por loja vs mesmo período ano passado ─────────────
+  const queryEvolLojasDetalhe = `
+    WITH
+    grupos_meta AS (
+      SELECT DISTINCT TRIM(codgrp) AS codgrp
+      FROM scc_metas_compradores
+      WHERE mes = EXTRACT(MONTH FROM $1::date)::int
+        AND ano = EXTRACT(YEAR  FROM $1::date)::int
+    ),
+    lojas AS (
+      SELECT lpad(gs::text, 2, '0') AS codloja
+      FROM generate_series(0, 11) gs
+    ),
+    base AS (
+      SELECT gm.codgrp, l.codloja
+      FROM grupos_meta gm
+      CROSS JOIN lojas l
+    ),
+    atual AS (
+      SELECT
+        TRIM(codgrp)  AS codgrp,
+        TRIM(codloja) AS codloja,
+        SUM(COALESCE(vlr_total_vendas_bruta,0) - COALESCE(vlr_total_devolucoes,0))       AS venda,
+        SUM(COALESCE(vlr_total_vendas_bruta,0) - COALESCE(vlr_custos_vendas,0)
+              - COALESCE(vlr_impostos_vendas,0))                                          AS lb,
+        SUM(COALESCE(vlr_total_vendas_bruta,0))                                           AS venda_bruta,
+        SUM(CASE WHEN tipo IN ('Fora','Encomenda','FORA','ENCO')
+                 THEN COALESCE(vlr_total_vendas_bruta,0) - COALESCE(vlr_total_devolucoes,0)
+                 ELSE 0 END)                                                              AS venda_fora
+      FROM vs_scc_vendas_devolucoes_lojas
+      WHERE data BETWEEN date_trunc('month', $1::date)::date AND $1::date
+        AND TRIM(codgrp) IN (SELECT codgrp FROM grupos_meta)
+      GROUP BY TRIM(codgrp), TRIM(codloja)
+    ),
+    anterior AS (
+      SELECT
+        TRIM(codgrp)  AS codgrp,
+        TRIM(codloja) AS codloja,
+        SUM(COALESCE(vlr_total_vendas_bruta,0) - COALESCE(vlr_total_devolucoes,0))       AS venda,
+        SUM(COALESCE(vlr_total_vendas_bruta,0) - COALESCE(vlr_custos_vendas,0)
+              - COALESCE(vlr_impostos_vendas,0))                                          AS lb,
+        SUM(COALESCE(vlr_total_vendas_bruta,0))                                           AS venda_bruta,
+        SUM(CASE WHEN tipo IN ('Fora','Encomenda','FORA','ENCO')
+                 THEN COALESCE(vlr_total_vendas_bruta,0) - COALESCE(vlr_total_devolucoes,0)
+                 ELSE 0 END)                                                              AS venda_fora
+      FROM vs_scc_vendas_devolucoes_lojas
+      WHERE data BETWEEN date_trunc('month', $1::date - interval '1 year')::date
+                     AND ($1::date - interval '1 year')::date
+        AND TRIM(codgrp) IN (SELECT codgrp FROM grupos_meta)
+      GROUP BY TRIM(codgrp), TRIM(codloja)
+    )
+    SELECT
+      b.codgrp,
+      b.codloja,
+      ROUND(CASE
+        WHEN COALESCE(a.venda,0) = 0 AND COALESCE(ant.venda,0) = 0 THEN NULL
+        WHEN COALESCE(ant.venda,0) = 0                              THEN  100.0
+        WHEN COALESCE(a.venda,0)   = 0                              THEN -100.0
+        ELSE (a.venda / ant.venda - 1) * 100
+      END, 1) AS evol_vendas,
+      ROUND(CASE
+        WHEN COALESCE(a.venda_bruta,0) > 0 AND COALESCE(ant.venda_bruta,0) > 0
+          THEN ((a.lb / a.venda_bruta) - (ant.lb / ant.venda_bruta)) * 100
+        ELSE NULL
+      END, 1) AS evol_lb,
+      ROUND(CASE
+        WHEN COALESCE(a.venda_fora,0) = 0 AND COALESCE(ant.venda_fora,0) = 0 THEN NULL
+        WHEN COALESCE(ant.venda_fora,0) = 0                                   THEN  100.0
+        WHEN COALESCE(a.venda_fora,0)   = 0                                   THEN -100.0
+        ELSE (a.venda_fora / ant.venda_fora - 1) * 100
+      END, 1) AS evol_prod_fora
+    FROM base b
+    LEFT JOIN atual    a   USING (codgrp, codloja)
+    LEFT JOIN anterior ant USING (codgrp, codloja)
+    ORDER BY b.codgrp, b.codloja
+  `
+
+  const [r1, r2, r3, r4, r5, r6] = await Promise.all([
+    pool.query(queryCompradores, p),
+    pool.query(queryGlobal, p),
+    pool.query(queryMetricsGrupo, p),
+    pool.query(queryNsLojasGrupo, p),
+    pool.query(queryNsLojasDetalhe, p),
+    pool.query(queryEvolLojasDetalhe, p).catch(() => ({ rows: [] })),
+  ])
+
+  // ── Mapas auxiliares (mesma lógica do dashboardTvComprasService) ──────────
+  const nsLojasMap = new Map<string, number>()
+  for (const row of r4.rows)
+    nsLojasMap.set(String(row.codgrp).trim(), safe(row.nivel_servico_lojas))
+  const nivelServicoLojasGlobal = nsLojasMap.get("__TOTAL__") ?? null
+
+  const nsLojasDetalheGrupoMap   = new Map<string, { codloja: string; nivelServico: number }[]>()
+  const diasLojasDetalheGrupoMap = new Map<string, { codloja: string; diasEstoque: number }[]>()
+  for (const row of r5.rows) {
+    if (row.tipo !== "grupo") continue
+    const loja = String(row.codloja).trim()
+    const key  = String(row.codgrp).trim()
+    if (!nsLojasDetalheGrupoMap.has(key))   nsLojasDetalheGrupoMap.set(key, [])
+    if (!diasLojasDetalheGrupoMap.has(key)) diasLojasDetalheGrupoMap.set(key, [])
+    nsLojasDetalheGrupoMap.get(key)!.push({ codloja: loja, nivelServico: safe(row.nivel_servico) })
+    diasLojasDetalheGrupoMap.get(key)!.push({ codloja: loja, diasEstoque: safe(row.dias_estoque) })
+  }
+
+  const evolLojasMap = new Map<string, { codloja: string; evolVendas: number | null; evolLb: number | null; evolProdFora: number | null }[]>()
+  for (const row of r6.rows) {
+    const key = String(row.codgrp).trim()
+    if (!evolLojasMap.has(key)) evolLojasMap.set(key, [])
+    evolLojasMap.get(key)!.push({
+      codloja:      String(row.codloja).trim(),
+      evolVendas:   row.evol_vendas   !== null ? Number(row.evol_vendas)   : null,
+      evolLb:       row.evol_lb       !== null ? Number(row.evol_lb)       : null,
+      evolProdFora: row.evol_prod_fora !== null ? Number(row.evol_prod_fora) : null,
+    })
+  }
+
+  const metricsGrupoMap = new Map<string, { nivelServico: number; diasEstoque: number }>()
+  for (const row of r3.rows)
+    metricsGrupoMap.set(String(row.codgrp).trim(), {
+      nivelServico: safe(row.nivel_servico),
+      diasEstoque:  safe(row.dias_estoque),
+    })
+
+  // ── Agrega por comprador (igual ao dashboardTvComprasService) ─────────────
+  interface CompRow {
+    comprador: string; grupos: string[]; grupoNomes: string[]
+    vendaRealizado: number; vendaBruta: number; lbRealizado: number
+    vendaForaRealizado: number; vendaAnoPassado: number
+    metaVendasAjustada: number; metaLbSum: number; metaProdutosForaAjustada: number
+    metaNivelServicoSum: number; metaDiasEstoqueSum: number; groupCount: number
+    nivelServico: number | null; nivelServicoLojasSum: number; nivelServicoLojasCount: number
+    diasEstoque: number | null
+  }
+
+  const compMap = new Map<string, CompRow>()
+  for (const row of r1.rows) {
+    const key    = row.comprador
+    const codgrp = String(row.codgrp).trim()
+    if (compMap.has(key)) {
+      const c = compMap.get(key)!
+      c.grupos.push(codgrp)
+      c.grupoNomes.push(String(row.grupo_nome || row.codgrp).trim())
+      c.vendaRealizado          += safe(row.venda_realizado)
+      c.vendaBruta              += safe(row.venda_bruta)
+      c.lbRealizado             += safe(row.lb_realizado)
+      c.vendaForaRealizado      += safe(row.venda_fora_realizado)
+      c.vendaAnoPassado         += safe(row.venda_ano_passado)
+      c.metaVendasAjustada      += safe(row.meta_vendas_ajustada)
+      c.metaLbSum               += safe(row.meta_lb)
+      c.metaProdutosForaAjustada += safe(row.meta_produtos_fora_ajustada)
+      c.metaNivelServicoSum     += safe(row.meta_nivel_servico)
+      c.metaDiasEstoqueSum      += safe(row.meta_dias_estoque)
+      c.groupCount++
+      const nsLojas = nsLojasMap.get(codgrp)
+      if (nsLojas !== undefined) { c.nivelServicoLojasSum += nsLojas; c.nivelServicoLojasCount++ }
+    } else {
+      const mg      = metricsGrupoMap.get(codgrp)
+      const nsLojas = nsLojasMap.get(codgrp)
+      compMap.set(key, {
+        comprador: row.comprador,
+        grupos:    [codgrp],
+        grupoNomes: [String(row.grupo_nome || row.codgrp).trim()],
+        vendaRealizado:           safe(row.venda_realizado),
+        vendaBruta:               safe(row.venda_bruta),
+        lbRealizado:              safe(row.lb_realizado),
+        vendaForaRealizado:       safe(row.venda_fora_realizado),
+        vendaAnoPassado:          safe(row.venda_ano_passado),
+        metaVendasAjustada:       safe(row.meta_vendas_ajustada),
+        metaLbSum:                safe(row.meta_lb),
+        metaProdutosForaAjustada: safe(row.meta_produtos_fora_ajustada),
+        metaNivelServicoSum:      safe(row.meta_nivel_servico),
+        metaDiasEstoqueSum:       safe(row.meta_dias_estoque),
+        groupCount:               1,
+        nivelServico:             mg ? mg.nivelServico : null,
+        nivelServicoLojasSum:     nsLojas !== undefined ? nsLojas : 0,
+        nivelServicoLojasCount:   nsLojas !== undefined ? 1 : 0,
+        diasEstoque:              mg ? mg.diasEstoque : null,
+      })
+    }
+  }
+
+  const compradores = Array.from(compMap.values()).map((c) => {
+    const gc               = c.groupCount || 1
+    const metaLb           = c.metaLbSum / gc
+    const metaNivelServico = c.metaNivelServicoSum / gc
+    const metaDiasEstoque  = c.metaDiasEstoqueSum / gc
+    const vendaMeta        = c.metaVendasAjustada > 0 ? (c.vendaRealizado / c.metaVendasAjustada) * 100 : 0
+    const lbPct            = c.vendaBruta > 0 ? (c.lbRealizado / c.vendaBruta) * 100 : 0
+    const evolucao         = c.vendaAnoPassado > 0 ? (c.vendaRealizado / c.vendaAnoPassado - 1) * 100 : 0
+    const produtosForaPct  = c.metaProdutosForaAjustada > 0 ? (c.vendaForaRealizado / c.metaProdutosForaAjustada) * 100 : 0
+
+    let nsMedia   = c.nivelServico
+    let diasMedia = c.diasEstoque
+    if (c.grupos.length > 1) {
+      const vals = c.grupos.map((g) => metricsGrupoMap.get(g)).filter(Boolean)
+      if (vals.length) {
+        nsMedia   = vals.reduce((s, v) => s + v!.nivelServico, 0) / vals.length
+        diasMedia = vals.reduce((s, v) => s + v!.diasEstoque, 0) / vals.length
+      }
+    }
+
+    return {
+      comprador:            c.comprador,
+      grupos:               c.grupoNomes.join(", "),
+      vendaRealizado:       Math.round(c.vendaRealizado),
+      metaVendasAjustada:   Math.round(c.metaVendasAjustada),
+      vendaPercentualMeta:  Number(vendaMeta.toFixed(1)),
+      lbPercentual:         Number(lbPct.toFixed(1)),
+      metaLb:               Number(metaLb.toFixed(1)),
+      nivelServico:         nsMedia !== null ? Number(nsMedia!.toFixed(1)) : null,
+      nivelServicoLojas:    c.nivelServicoLojasCount > 0
+                              ? Number((c.nivelServicoLojasSum / c.nivelServicoLojasCount).toFixed(1))
+                              : null,
+      nivelServicoMeta:     Math.round(metaNivelServico),
+      diasEstoque:          diasMedia !== null ? Math.round(diasMedia!) : null,
+      diasEstoqueMeta:      Math.round(metaDiasEstoque),
+      evolucaoPercentual:   Number(evolucao.toFixed(1)),
+      produtosForaPercentual: Number(produtosForaPct.toFixed(1)),
+    }
+  }).sort((a, b) => safe(b.vendaRealizado) - safe(a.vendaRealizado))
+
+  // ── compradoresGrupos (linhas da tabela matriz) ────────────────────────────
+  const compradoresGrupos = r1.rows.map((row: any) => {
+    const codgrp            = String(row.codgrp).trim()
+    const mg                = metricsGrupoMap.get(codgrp)
+    const vendaBruta        = safe(row.venda_bruta)
+    const lbRealizado       = safe(row.lb_realizado)
+    const lbPct             = vendaBruta > 0 ? (lbRealizado / vendaBruta) * 100 : 0
+    const metaVendasAjustada = safe(row.meta_vendas_ajustada)
+    const vendaRealizado    = safe(row.venda_realizado)
+    const vendaPercentualMeta = metaVendasAjustada > 0 ? (vendaRealizado / metaVendasAjustada) * 100 : 0
+    const metaProdutosForaAjustada = safe(row.meta_produtos_fora_ajustada)
+    const vendaForaRealizado = safe(row.venda_fora_realizado)
+    const produtosForaPct   = metaProdutosForaAjustada > 0 ? (vendaForaRealizado / metaProdutosForaAjustada) * 100 : 0
+    return {
+      comprador:            row.comprador,
+      codgrp,
+      grupoNome:            String(row.grupo_nome || row.codgrp).trim(),
+      vendaPercentualMeta:  Number(vendaPercentualMeta.toFixed(1)),
+      lbPercentual:         Number(lbPct.toFixed(1)),
+      metaLb:               Number(safe(row.meta_lb).toFixed(1)),
+      nivelServico:         mg ? Number(mg.nivelServico.toFixed(1)) : null,
+      nivelServicoLojas:    nsLojasMap.has(codgrp) ? Number(nsLojasMap.get(codgrp)!.toFixed(1)) : null,
+      nsPorLoja:            nsLojasDetalheGrupoMap.get(codgrp) ?? [],
+      diasPorLoja:          diasLojasDetalheGrupoMap.get(codgrp) ?? [],
+      evolPorLoja:          evolLojasMap.get(codgrp) ?? [],
+      nivelServicoMeta:     safe(row.meta_nivel_servico) || 97,
+      diasEstoque:          mg ? Math.round(mg.diasEstoque) : null,
+      diasEstoqueMeta:      safe(row.meta_dias_estoque) || 45,
+      produtosForaPercentual: Number(produtosForaPct.toFixed(1)),
+    }
+  })
+
+  // ── KPIs globais ───────────────────────────────────────────────────────────
+  const gm          = r2.rows[0] ?? {}
+  const vendasValor = safe(gm.vendas_valor)
+  const vendaBruta  = safe(gm.venda_bruta)
+  const lbValor     = safe(gm.lb_valor)
+  const produtosForaValor = safe(gm.produtos_fora_valor)
+  const lbPct       = vendaBruta > 0 ? lbValor / vendaBruta * 100 : 0
+  const totalDias   = safe(gm.total_dias)
+  const diasDecorridos = safe(gm.dias_decorridos)
+
+  const metaVendasAjustada      = totalDias > 0
+    ? Math.round(safe(gm.meta_vendas) * diasDecorridos / totalDias) : safe(gm.meta_vendas)
+  const metaProdutosForaAjustada = totalDias > 0
+    ? Math.round(safe(gm.meta_produtos_fora) * diasDecorridos / totalDias) : safe(gm.meta_produtos_fora)
+
+  const kpis = {
+    lbPercentual:    Number(lbPct.toFixed(1)),
+    metaLb:          Number(safe(gm.meta_lb_media).toFixed(1)),
+    nivelServico:    safe(gm.nivel_servico),
+    nivelServicoLojas: nivelServicoLojasGlobal,
+    nivelServicoMeta: Math.round(safe(gm.meta_nivel_servico_media)) || 98,
+    diasEstoque:     (() => {
+      const vals = Array.from(metricsGrupoMap.values()).map(m => m.diasEstoque).filter(d => d > 0)
+      return vals.length > 0 ? Math.round(vals.reduce((s, v) => s + v, 0) / vals.length) : safe(gm.dias_estoque)
+    })(),
+    diasEstoqueMeta: Math.round(safe(gm.meta_dias_estoque_media)) || 45,
+    vendasAtingimento: metaVendasAjustada > 0
+      ? Number((vendasValor / metaVendasAjustada * 100).toFixed(2)) : 0,
+    lbRealizado: Number(lbPct.toFixed(1)),
+    produtosFora: metaProdutosForaAjustada > 0
+      ? Number((produtosForaValor / metaProdutosForaAjustada * 100).toFixed(2)) : 0,
+  }
+
+  return { kpis, compradores, compradoresGrupos }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,7 @@ import { ThemeProvider } from "./contexts/ThemeContext"
 import Compradores from "./pages/Compradores"
 import CompradoresGrupos from "./pages/CompradoresGrupos"
 import CompradoresMetas from "./pages/CompradoresMetas"
+import CompradoresDesempenho from "./pages/CompradoresDesempenho"
 import TvCompras from "./pages/TvCompras"
 import TvComprasLojas from "./pages/TvComprasLojas"
 
@@ -296,6 +297,7 @@ function App() {
             <Route path="/compradores" element={<ProtectedRoute><Layout><Compradores /></Layout></ProtectedRoute>} />
             <Route path="/compradores/grupos" element={<ProtectedRoute><Layout><CompradoresGrupos /></Layout></ProtectedRoute>} />
             <Route path="/compradores/metas" element={<ProtectedRoute><Layout><CompradoresMetas /></Layout></ProtectedRoute>} />
+            <Route path="/compradores/desempenho" element={<ProtectedRoute><Layout><CompradoresDesempenho /></Layout></ProtectedRoute>} />
           </Routes>
         </AuthProvider>
       </Router>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -150,6 +150,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
                 { text: "Compradores", icon: <PersonIcon />, path: "/compradores" },
                 { text: "Grupos", icon: <BarChart />, path: "/compradores/grupos" },
                 { text: "Metas", icon: <AttachMoney />, path: "/compradores/metas" },
+                { text: "Desempenho", icon: <BarChart />, path: "/compradores/desempenho" },
             ],
         },
         {

--- a/frontend/src/pages/CompradoresDesempenho.tsx
+++ b/frontend/src/pages/CompradoresDesempenho.tsx
@@ -1,0 +1,441 @@
+import React, { useState } from "react"
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Typography,
+} from "@mui/material"
+import { getCompradoresHistorico } from "../services/compradoresHistoricoService"
+
+// ─── Paleta (idêntica ao TvComprasLojas) ─────────────────────────────────────
+const C = {
+  bg:     "#04091A",
+  card:   "#070D1C",
+  border: "#0F1D35",
+  text:   "#F1F5F9",
+  muted:  "#94A3B8",
+  dim:    "#1E293B",
+  blue:   "#1D9BF0",
+  green:  "#22C55E",
+  orange: "#FB923C",
+  red:    "#EF4444",
+  yellow: "#EAB308",
+}
+
+const safe = (v: unknown) => (Number.isFinite(Number(v)) ? Number(v) : 0)
+
+// ─── Barra de atingimento ─────────────────────────────────────────────────────
+function AtingBar({ pct, meta = 100, height = 7 }: { pct: number; meta?: number; height?: number }) {
+  const color = pct >= meta ? C.green : pct >= 90 ? C.orange : C.red
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 3, width: "100%" }}>
+      <div style={{ flex: 1, height, background: C.dim, borderRadius: 3, overflow: "hidden" }}>
+        <div style={{ width: `${Math.min(100, pct)}%`, height: "100%", background: color, borderRadius: 3 }} />
+      </div>
+      <span style={{ fontSize: 12, color, fontWeight: 700, width: 36, flexShrink: 0 }}>{pct.toFixed(0)}%</span>
+    </div>
+  )
+}
+
+// ─── Card KPI total geral ─────────────────────────────────────────────────────
+function TotalCard({ icon, label, pct }: { icon: string; label: string; pct: number }) {
+  const color = pct >= 100 ? C.green : pct >= 90 ? C.orange : C.red
+  return (
+    <div style={{
+      background: "#040A18", border: `1px solid ${color}44`,
+      borderTop: `2px solid ${color}`, borderRadius: 6,
+      padding: "8px 12px", display: "flex", flexDirection: "column",
+      alignItems: "center", gap: 4, minWidth: 105,
+    }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+        <span style={{ fontSize: 13 }}>{icon}</span>
+        <span style={{ fontSize: 9, color: C.muted, fontWeight: 600, letterSpacing: "0.07em", textTransform: "uppercase" }}>{label}</span>
+      </div>
+      <div style={{ fontSize: 24, fontWeight: 800, color, fontVariantNumeric: "tabular-nums", lineHeight: 1 }}>
+        {pct.toFixed(0)}%
+      </div>
+      <div style={{ width: "100%", height: 4, background: C.dim, borderRadius: 2, overflow: "hidden" }}>
+        <div style={{ width: `${Math.min(100, pct)}%`, height: "100%", background: color, borderRadius: 2 }} />
+      </div>
+    </div>
+  )
+}
+
+// ─── Chips de NS por loja ─────────────────────────────────────────────────────
+function NsLojaChips({ lojas, meta = 97, overall }: {
+  lojas: { codloja: string; nivelServico: number }[]
+  meta?: number
+  overall?: number
+}) {
+  if (!lojas.length) return <span style={{ color: C.muted, fontSize: 10 }}>—</span>
+  const overallColor = overall !== undefined
+    ? (overall >= meta ? C.green : overall >= meta * 0.9 ? C.orange : C.red) : C.muted
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      {overall !== undefined && (
+        <div style={{ display: "flex", alignItems: "center", gap: 3 }}>
+          <span style={{ fontSize: 12, fontWeight: 800, color: overallColor, fontVariantNumeric: "tabular-nums" }}>
+            {overall.toFixed(0)}%
+          </span>
+          <div style={{ flex: 1, height: 5, background: C.dim, borderRadius: 2, overflow: "hidden" }}>
+            <div style={{ width: `${Math.min(100, overall / meta * 100)}%`, height: "100%", background: overallColor, borderRadius: 2 }} />
+          </div>
+        </div>
+      )}
+      <div style={{ display: "flex", flexWrap: "nowrap", gap: 1 }}>
+        {lojas.map(l => {
+          const ns = l.nivelServico
+          const color = ns >= meta ? C.green : ns >= meta * 0.9 ? C.orange : C.red
+          return (
+            <div key={l.codloja} style={{
+              display: "flex", flexDirection: "column", alignItems: "center",
+              background: color + "1A", border: `1px solid ${color}55`,
+              borderRadius: 2, padding: "0px 3px", minWidth: 20,
+            }}>
+              <span style={{ fontSize: 6, color: C.muted, lineHeight: 1.3 }}>{l.codloja}</span>
+              <span style={{ fontSize: 7, color, fontWeight: 700, lineHeight: 1.2, fontVariantNumeric: "tabular-nums" }}>{ns}%</span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+// ─── Chips de dias de estoque por loja ───────────────────────────────────────
+function DiasLojaChips({ lojas, meta = 45 }: { lojas: { codloja: string; diasEstoque: number }[]; meta?: number }) {
+  if (!lojas.length) return null
+  return (
+    <div style={{ display: "flex", flexWrap: "nowrap", gap: 1, marginTop: 2 }}>
+      {lojas.map(l => {
+        const d = l.diasEstoque
+        const color = d <= meta ? C.green : d <= meta * 1.2 ? C.orange : C.red
+        return (
+          <div key={l.codloja} style={{
+            display: "flex", flexDirection: "column", alignItems: "center",
+            background: color + "1A", border: `1px solid ${color}55`,
+            borderRadius: 2, padding: "0px 3px", minWidth: 20,
+          }}>
+            <span style={{ fontSize: 6, color: C.muted, lineHeight: 1.3 }}>{l.codloja}</span>
+            <span style={{ fontSize: 7, color, fontWeight: 700, lineHeight: 1.2, fontVariantNumeric: "tabular-nums" }}>{d}d</span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+// ─── Chips de evolução por loja ───────────────────────────────────────────────
+function EvolLojaChips({ lojas, field }: {
+  lojas: { codloja: string; evolVendas: number | null; evolLb: number | null; evolProdFora: number | null }[]
+  field: "evolVendas" | "evolLb" | "evolProdFora"
+}) {
+  if (!lojas.length) return null
+  return (
+    <div style={{ display: "flex", flexWrap: "nowrap", gap: 1, marginTop: 2 }}>
+      {lojas.map(l => {
+        const v = l[field]
+        if (v === null) {
+          return (
+            <div key={l.codloja} style={{
+              display: "flex", flexDirection: "column", alignItems: "center",
+              background: C.dim + "88", border: `1px solid ${C.border}`,
+              borderRadius: 2, padding: "0px 3px", minWidth: 20,
+            }}>
+              <span style={{ fontSize: 6, color: C.muted, lineHeight: 1.3 }}>{l.codloja}</span>
+              <span style={{ fontSize: 7, color: C.muted, fontWeight: 500, lineHeight: 1.2 }}>–</span>
+            </div>
+          )
+        }
+        const color = v >= 0 ? C.green : v >= -10 ? C.orange : C.red
+        const sign  = v > 0 ? "+" : ""
+        return (
+          <div key={l.codloja} style={{
+            display: "flex", flexDirection: "column", alignItems: "center",
+            background: color + "1A", border: `1px solid ${color}55`,
+            borderRadius: 2, padding: "0px 3px", minWidth: 20,
+          }}>
+            <span style={{ fontSize: 6, color: C.muted, lineHeight: 1.3 }}>{l.codloja}</span>
+            <span style={{ fontSize: 7, color, fontWeight: 700, lineHeight: 1.2, fontVariantNumeric: "tabular-nums" }}>{sign}{v.toFixed(0)}%</span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+// ─── Ícones de meta (V L N D P) ──────────────────────────────────────────────
+function MetaIcons({ c }: { c: any }) {
+  const nsReal = c.nivelServicoLojas !== null && c.nivelServicoLojas !== undefined
+    ? safe(c.nivelServicoLojas) : safe(c.nivelServico)
+  const nsDisponivel = c.nivelServicoLojas !== null && c.nivelServicoLojas !== undefined
+    ? true : c.nivelServico !== null
+  const items = [
+    { key: "V", ok: safe(c.vendaPercentualMeta) >= 100,                                        title: "Vendas" },
+    { key: "L", ok: safe(c.lbPercentual) >= safe(c.metaLb),                                    title: "LB" },
+    { key: "N", ok: nsDisponivel && nsReal >= (c.nivelServicoMeta || 97),                       title: "Nível Serviço" },
+    { key: "D", ok: c.diasEstoque !== null && safe(c.diasEstoque) <= (c.diasEstoqueMeta || 45), title: "Dias Estoque" },
+    { key: "P", ok: safe(c.produtosForaPercentual) >= 100,                                      title: "Prod. Fora" },
+  ]
+  return (
+    <div style={{ display: "flex", gap: 2 }}>
+      {items.map(({ key, ok, title }) => (
+        <div key={key} title={title} style={{
+          width: 16, height: 16, borderRadius: 2,
+          background: ok ? "#052e16" : "#3f0000",
+          border: `1px solid ${ok ? C.green : C.red}`,
+          display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center",
+        }}>
+          <span style={{ fontSize: 6, color: ok ? C.green : C.red, fontWeight: 800, lineHeight: 1 }}>{key}</span>
+          <span style={{ fontSize: 7, color: ok ? C.green : C.red, lineHeight: 1 }}>{ok ? "✓" : "✗"}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ─── Componente principal ─────────────────────────────────────────────────────
+const MESES = ["Janeiro","Fevereiro","Março","Abril","Maio","Junho","Julho","Agosto","Setembro","Outubro","Novembro","Dezembro"]
+
+const anoAtual = new Date().getFullYear()
+const mesAtual = new Date().getMonth() + 1
+// Padrão: mês passado
+const defaultAno = mesAtual === 1 ? anoAtual - 1 : anoAtual
+const defaultMes = mesAtual === 1 ? 12 : mesAtual - 1
+
+export default function CompradoresDesempenho() {
+  const [ano, setAno]       = useState(defaultAno)
+  const [mes, setMes]       = useState(defaultMes)
+  const [data, setData]     = useState<any>(null)
+  const [loading, setLoading] = useState(false)
+  const [erro, setErro]     = useState<string | null>(null)
+
+  const anos = Array.from({ length: 5 }, (_, i) => anoAtual - i)
+
+  const carregar = async () => {
+    setLoading(true); setErro(null)
+    try {
+      const result = await getCompradoresHistorico(ano, mes)
+      setData(result)
+    } catch (e: any) {
+      setErro(e?.response?.data?.message ?? "Erro ao carregar dados.")
+    } finally { setLoading(false) }
+  }
+
+  const kpis               = data?.kpis ?? {}
+  const comps: any[]       = data?.compradores ?? []
+  const gruposFlat: any[]  = data?.compradoresGrupos ?? []
+  const mesLabel           = `${MESES[mes - 1]}/${ano}`
+
+  const totalVendas = safe(kpis.vendasAtingimento)
+  const totalLb     = safe(kpis.metaLb) > 0 ? safe(kpis.lbPercentual) / safe(kpis.metaLb) * 100 : 0
+  const nsLojasGlobal = kpis.nivelServicoLojas !== null && kpis.nivelServicoLojas !== undefined
+    ? safe(kpis.nivelServicoLojas) : safe(kpis.nivelServico)
+  const totalNs     = safe(kpis.nivelServicoMeta) > 0 ? nsLojasGlobal / safe(kpis.nivelServicoMeta) * 100 : 0
+  const totalDias   = safe(kpis.diasEstoque) > 0 ? safe(kpis.diasEstoqueMeta) / safe(kpis.diasEstoque) * 100 : 0
+  const totalProd   = safe(kpis.produtosFora)
+
+  // Matriz comprador × grupos (ordenada por faturamento, igual ao TV)
+  const compMap = new Map<string, any>()
+  for (const c of comps) compMap.set(c.comprador, c)
+  const matrizCompradores = (() => {
+    const map = new Map<string, any[]>()
+    for (const g of gruposFlat) {
+      if (!map.has(g.comprador)) map.set(g.comprador, [])
+      map.get(g.comprador)!.push(g)
+    }
+    return Array.from(map.entries()).map(([comprador, grupos]) => ({
+      comprador, grupos, sub: compMap.get(comprador) ?? null,
+    })).sort((a, b) => safe(b.sub?.vendaRealizado) - safe(a.sub?.vendaRealizado))
+  })()
+
+  const lbAting   = (g: any) => safe(g.metaLb) > 0 ? safe(g.lbPercentual) / safe(g.metaLb) * 100 : 0
+  const nsVal     = (g: any) => g.nivelServicoLojas !== null && g.nivelServicoLojas !== undefined
+    ? safe(g.nivelServicoLojas) : safe(g.nivelServico)
+  const nsPresent = (g: any) => g.nivelServicoLojas !== null && g.nivelServicoLojas !== undefined
+    ? true : g.nivelServico !== null
+  const nsAting   = (g: any) => (g.nivelServicoMeta || 97) > 0 ? nsVal(g) / (g.nivelServicoMeta || 97) * 100 : 0
+  const diasAting = (g: any) => { const r = safe(g.diasEstoque); return r > 0 ? (g.diasEstoqueMeta || 45) / r * 100 : 0 }
+
+  const th: React.CSSProperties = {
+    color: C.muted, fontSize: 9, fontWeight: 600, textTransform: "uppercase",
+    letterSpacing: "0.04em", padding: "3px 5px", whiteSpace: "nowrap",
+    borderBottom: `1px solid ${C.border}`,
+  }
+  const td: React.CSSProperties = { color: C.text, fontSize: 10, padding: "2px 4px", borderBottom: `1px solid ${C.dim}` }
+  const tdN: React.CSSProperties = { ...td, color: C.muted }
+  const thG: React.CSSProperties = { ...th, borderLeft: `2px solid ${C.border}` }
+  const tdG: React.CSSProperties = { ...td, borderLeft: `2px solid ${C.dim}` }
+  const W = "2px solid rgba(255,255,255,0.42)"
+  const tdSub: React.CSSProperties = {
+    fontSize: 10, fontWeight: 700, padding: "2px 4px",
+    background: "#0A1628", borderTop: `1px solid ${C.border}`,
+    borderBottom: `1px solid ${C.border}`, color: C.blue,
+  }
+  const tdSubG: React.CSSProperties = { ...tdSub, borderLeft: `2px solid ${C.border}` }
+
+  return (
+    <Box p={3}>
+      <Typography variant="h5" fontWeight={700} sx={{ mb: 2 }}>
+        Desempenho de Compradores
+      </Typography>
+
+      {/* ── Filtro de período ── */}
+      <Paper sx={{ p: 2, mb: 2 }}>
+        <Box display="flex" gap={2} alignItems="center" flexWrap="wrap">
+          <FormControl size="small" sx={{ minWidth: 100 }}>
+            <InputLabel>Ano</InputLabel>
+            <Select value={ano} label="Ano" onChange={(e) => setAno(Number(e.target.value))}>
+              {anos.map((a) => <MenuItem key={a} value={a}>{a}</MenuItem>)}
+            </Select>
+          </FormControl>
+          <FormControl size="small" sx={{ minWidth: 140 }}>
+            <InputLabel>Mês</InputLabel>
+            <Select value={mes} label="Mês" onChange={(e) => setMes(Number(e.target.value))}>
+              {MESES.map((m, i) => <MenuItem key={i + 1} value={i + 1}>{m}</MenuItem>)}
+            </Select>
+          </FormControl>
+          <Button variant="contained" onClick={carregar} disabled={loading}>
+            {loading ? <CircularProgress size={18} sx={{ color: "white" }} /> : "Filtrar"}
+          </Button>
+          {data && (
+            <Typography variant="body2" color="text.secondary">
+              Exibindo: <strong>{mesLabel}</strong>
+            </Typography>
+          )}
+        </Box>
+        {erro && <Alert severity="error" sx={{ mt: 1 }}>{erro}</Alert>}
+      </Paper>
+
+      {/* ── Resultado (mesmo visual do TvComprasLojas) ── */}
+      {data && (
+        <div style={{ background: C.bg, color: C.text, padding: "6px 10px", borderRadius: 8, fontFamily: "'Segoe UI', sans-serif" }}>
+
+          {/* TOTAL GERAL */}
+          <div style={{ background: C.card, border: `1px solid ${C.border}`, borderRadius: 6, padding: "5px 10px", marginBottom: 6 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+              <span style={{ color: C.blue, fontWeight: 800, fontSize: 11, letterSpacing: "0.1em" }}>
+                TOTAL GERAL — {mesLabel.toUpperCase()}
+              </span>
+              <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+                <TotalCard icon="💰" label="Vendas Atingimento" pct={totalVendas} />
+                <TotalCard icon="📊" label="LB Atingimento"     pct={totalLb} />
+                <TotalCard icon="🚚" label="Nível Serviço"      pct={totalNs} />
+                <TotalCard icon="📦" label="Dias Estoque"       pct={totalDias} />
+                <TotalCard icon="🏷️" label="Prod. Fora"        pct={totalProd} />
+              </div>
+            </div>
+          </div>
+
+          {/* TABELA MATRIZ */}
+          <div style={{ background: C.card, border: `1px solid ${C.border}`, borderRadius: 6, padding: "4px 6px", overflowX: "auto" }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 4 }}>
+              <span style={{ color: C.blue, fontWeight: 700, fontSize: 10, letterSpacing: "0.08em" }}>👥 DESEMPENHO POR COMPRADOR E GRUPO</span>
+              <span style={{ color: C.muted, fontSize: 9 }}>Referência: {mesLabel}</span>
+            </div>
+            <table style={{ width: "100%", borderCollapse: "collapse" }}>
+              <thead>
+                <tr>
+                  <th style={th}>Comprador</th>
+                  <th style={th}>Grupo</th>
+                  <th style={{ ...thG, textAlign: "center" }}>Vendas Atingimento</th>
+                  <th style={{ ...thG, textAlign: "center" }}>LB Atingimento</th>
+                  <th style={{ ...thG, textAlign: "center" }}>Nível Serviço Atingimento</th>
+                  <th style={{ ...thG, textAlign: "center" }}>Dias Estoque Atingimento</th>
+                  <th style={{ ...thG, textAlign: "center" }}>Prod. Fora Atingimento</th>
+                  <th style={{ ...thG, textAlign: "center" }}>Metas</th>
+                </tr>
+              </thead>
+              <tbody>
+                {matrizCompradores.length > 0 ? matrizCompradores.flatMap((m, mi) => {
+                  const rowBg    = mi % 2 === 1 ? "#060C1A" : "transparent"
+                  const firstName = m.comprador.split(" ")[0]
+
+                  const grupoRows = m.grupos.map((g: any, gi: number) => {
+                    const isFirst  = gi === 0
+                    const topB: React.CSSProperties     = isFirst ? { borderTop: W } : {}
+                    const leftGrupo: React.CSSProperties = isFirst ? {} : { borderLeft: W }
+                    return (
+                      <tr key={`${mi}-${gi}`} style={{ background: rowBg }}>
+                        {isFirst && (
+                          <td style={{ ...td, ...topB, borderLeft: W, verticalAlign: "middle", fontWeight: 700, whiteSpace: "nowrap", color: C.blue }}
+                            rowSpan={m.grupos.length}>
+                            {m.comprador}
+                          </td>
+                        )}
+                        <td style={{ ...tdN, ...topB, ...leftGrupo, fontSize: 9 }}>{g.grupoNome}</td>
+                        <td style={{ ...tdG, ...topB, whiteSpace: "nowrap" }}>
+                          <AtingBar pct={safe(g.vendaPercentualMeta)} />
+                          <EvolLojaChips lojas={g.evolPorLoja ?? []} field="evolVendas" />
+                        </td>
+                        <td style={{ ...tdG, ...topB, whiteSpace: "nowrap" }}>
+                          <AtingBar pct={lbAting(g)} />
+                          <EvolLojaChips lojas={g.evolPorLoja ?? []} field="evolLb" />
+                        </td>
+                        <td style={{ ...tdG, ...topB, whiteSpace: "nowrap" }}>
+                          <NsLojaChips
+                            lojas={g.nsPorLoja ?? []}
+                            meta={g.nivelServicoMeta || 97}
+                            overall={nsPresent(g) ? nsVal(g) : undefined}
+                          />
+                        </td>
+                        <td style={{ ...tdG, ...topB, whiteSpace: "nowrap" }}>
+                          <AtingBar pct={diasAting(g)} />
+                          <DiasLojaChips lojas={g.diasPorLoja ?? []} meta={g.diasEstoqueMeta || 45} />
+                        </td>
+                        <td style={{ ...tdG, ...topB, whiteSpace: "nowrap" }}>
+                          <AtingBar pct={safe(g.produtosForaPercentual)} />
+                          <EvolLojaChips lojas={g.evolPorLoja ?? []} field="evolProdFora" />
+                        </td>
+                        <td style={{ ...tdG, ...topB, borderRight: W }}><MetaIcons c={g} /></td>
+                      </tr>
+                    )
+                  })
+
+                  const sub = m.sub
+                  const subRow = sub ? (
+                    <tr key={`${mi}-sub`}>
+                      <td style={{ ...tdSub, borderLeft: W, borderBottom: W, fontStyle: "italic" }} colSpan={2}>
+                        SUB-TOTAL {firstName.toUpperCase()}
+                      </td>
+                      <td style={{ ...tdSubG, borderBottom: W }}><AtingBar pct={safe(sub.vendaPercentualMeta)} height={10} /></td>
+                      <td style={{ ...tdSubG, borderBottom: W }}><AtingBar pct={lbAting(sub)} height={10} /></td>
+                      <td style={{ ...tdSubG, borderBottom: W }}>
+                        {nsPresent(sub) ? <AtingBar pct={nsAting(sub)} height={10} /> : <span style={{ color: C.muted }}>—</span>}
+                      </td>
+                      <td style={{ ...tdSubG, borderBottom: W }}>
+                        {sub.diasEstoque !== null ? <AtingBar pct={diasAting(sub)} height={10} /> : <span style={{ color: C.muted }}>—</span>}
+                      </td>
+                      <td style={{ ...tdSubG, borderBottom: W }}><AtingBar pct={safe(sub.produtosForaPercentual)} height={10} /></td>
+                      <td style={{ ...tdSubG, borderBottom: W, borderRight: W }}><MetaIcons c={sub} /></td>
+                    </tr>
+                  ) : null
+
+                  const spacer = <tr key={`${mi}-spacer`} style={{ height: 4 }}><td colSpan={8} style={{ padding: 0, border: "none", background: "transparent" }} /></tr>
+                  const rows = subRow ? [...grupoRows, subRow] : grupoRows
+                  return mi < matrizCompradores.length - 1 ? [...rows, spacer] : rows
+                }) : (
+                  <tr><td colSpan={8} style={{ ...td, textAlign: "center", color: C.muted, padding: "20px 0" }}>
+                    Nenhum dado encontrado para {mesLabel}.
+                  </td></tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {!data && !loading && (
+        <Paper sx={{ p: 3 }}>
+          <Typography color="text.secondary">Selecione ano e mês e clique em Filtrar para carregar o desempenho.</Typography>
+        </Paper>
+      )}
+    </Box>
+  )
+}

--- a/frontend/src/services/compradoresHistoricoService.ts
+++ b/frontend/src/services/compradoresHistoricoService.ts
@@ -1,0 +1,6 @@
+import api from "./api"
+
+export const getCompradoresHistorico = async (ano: number, mes: number) => {
+  const response = await api.get("/compradores/historico", { params: { ano, mes } })
+  return response.data
+}


### PR DESCRIPTION
Permite verificar quem bateu meta em meses anteriores com o mesmo visual da TV Compras Lojas (barras de atingimento, chips por loja, ícones V/L/N/D/P, cards de total geral).

Backend:
- services/compradoresHistoricoService.ts: queries parametrizadas por $1::date (último dia do mês solicitado) — 6 queries cobrindo compradores, KPIs, NS/dias, NS por loja e evolução por loja
- controllers/compradoresHistoricoController.ts: valida ano/mes
- routes/compradoresHistoricoRoutes.ts: GET /compradores/historico
- app.ts: rota /api/compradores registrada

Frontend:
- pages/CompradoresDesempenho.tsx: seletor ano/mês + visual idêntico ao TvComprasLojas (sem elementos de TV), padrão = mês passado
- services/compradoresHistoricoService.ts: chamada à API
- App.tsx: rota /compradores/desempenho
- Layout.tsx: item "Desempenho" no menu Compradores