### PR TITLE
fix: remove verificarPermissao da rota de histórico de compradores

### DIFF
--- a/backend/src/routes/compradoresHistoricoRoutes.ts
+++ b/backend/src/routes/compradoresHistoricoRoutes.ts
@@ -1,10 +1,10 @@
 import { Router } from "express"
 import { getCompradoresHistorico } from "../controllers/compradoresHistoricoController"
-import { verificarAutenticacao, verificarPermissao } from "../middlewares/authMiddleware"
+import { verificarAutenticacao } from "../middlewares/authMiddleware"
 
 const router = Router()
 
 router.use(verificarAutenticacao)
-router.get("/historico", verificarPermissao("compradores", "visualizar"), getCompradoresHistorico)
+router.get("/historico", getCompradoresHistorico)
 
 export default router


### PR DESCRIPTION
As rotas de compradores não usam controle de permissão por módulo, apenas autenticação. O verificarPermissao('compradores', 'visualizar') gerava 403 para todos os usuários.